### PR TITLE
feat(ci): add docker image build job for proposer / challenger

### DIFF
--- a/.github/workflows/docker-build-lite-celo.yaml
+++ b/.github/workflows/docker-build-lite-celo.yaml
@@ -9,6 +9,9 @@ on:
       - develop
   workflow_dispatch:
 
+env:
+  REGISTRY_URL: us-west1-docker.pkg.dev/blockchaintestsglobaltestnet/dev-images/${{ github.event.repository.name }}
+
 jobs:
   build:
     name: Build OP Succinct Lite Docker Images
@@ -34,7 +37,7 @@ jobs:
         id: meta-proposer
         uses: docker/metadata-action@v5
         with:
-          images: us-west1-docker.pkg.dev/blockchaintestsglobaltestnet/dev-images/celo-succinct-proposer
+          images: ${{ env.REGISTRY_URL }}/proposer
           tags: |
             type=semver,pattern={{version}}
             type=edge
@@ -44,7 +47,7 @@ jobs:
         id: meta-challenger
         uses: docker/metadata-action@v5
         with:
-          images: us-west1-docker.pkg.dev/blockchaintestsglobaltestnet/dev-images/celo-succinct-proposer
+          images: ${{ env.REGISTRY_URL }}/challenger
           tags: |
             type=semver,pattern={{version}}
             type=edge
@@ -68,8 +71,8 @@ jobs:
           platforms: |
             linux/amd64
             linux/arm64
-          cache-from: type=registry
-          cache-to: type=registry,mode=max
+          cache-from: type=registry,ref=${{ env.REGISTRY_URL }}/proposer-buildcache:buildcache
+          cache-to: type=registry,mode=max,ref=${{ env.REGISTRY_URL }}/proposer-buildcache:buildcache
 
       - name: Build and push challenger
         uses: docker/build-push-action@v6
@@ -82,5 +85,5 @@ jobs:
           platforms: |
             linux/amd64
             linux/arm64
-          cache-from: type=registry
-          cache-to: type=registry,mode=max
+          cache-from: type=registry,ref=${{ env.REGISTRY_URL }}/challenger-buildcache:buildcache
+          cache-to: type=registry,mode=max,ref=${{ env.REGISTRY_URL }}/challenger-buildcache:buildcache

--- a/.github/workflows/docker-build-lite-celo.yaml
+++ b/.github/workflows/docker-build-lite-celo.yaml
@@ -17,6 +17,10 @@ jobs:
       - org
       - 8-cpu
 
+    permissions:
+      contents: read
+      id-token: write
+      security-events: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/docker-build-lite-celo.yaml
+++ b/.github/workflows/docker-build-lite-celo.yaml
@@ -1,0 +1,82 @@
+name: Build Celo / OP Succinct Lite Docker Images
+
+on:
+  pull_request:
+    branches:
+      - develop
+  push:
+    branches:
+      - develop
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build OP Succinct Lite Docker Images
+    runs-on:
+      - self-hosted
+      - org
+      - 8-cpu
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }} # Check out the PR head, rather than the merge commit.
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker meta for proposer
+        id: meta-proposer
+        uses: docker/metadata-action@v5
+        with:
+          images: us-west1-docker.pkg.dev/blockchaintestsglobaltestnet/dev-images/celo-succinct-proposer
+          tags: |
+            type=semver,pattern={{version}}
+            type=edge
+            type=sha
+
+      - name: Docker meta for challenger
+        id: meta-challenger
+        uses: docker/metadata-action@v5
+        with:
+          images: us-west1-docker.pkg.dev/blockchaintestsglobaltestnet/dev-images/celo-succinct-proposer
+          tags: |
+            type=semver,pattern={{version}}
+            type=edge
+            type=sha
+
+      - name: Login at GCP Artifact Registry
+        uses: celo-org/reusable-workflows/.github/actions/auth-gcp-artifact-registry@v2.0
+        with:
+          workload-id-provider: "projects/1094498259535/locations/global/workloadIdentityPools/gh-op-succinct-dev/providers/github-by-repos"
+          service-account: "op-succinct-dev@blockchaintestsglobaltestnet.iam.gserviceaccount.com"
+          docker-gcp-registries: us-west1-docker.pkg.dev
+
+      - name: Build and push proposer
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: fault_proof/Dockerfile.proposer
+          push: true
+          tags: ${{ steps.meta-proposer.outputs.tags }}
+          labels: ${{ steps.meta-proposer.outputs.labels }}
+          platforms: |
+            linux/amd64
+            linux/arm64
+          cache-from: type=registry
+          cache-to: type=registry,mode=max
+
+      - name: Build and push challenger
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: fault_proof/Dockerfile.challenger
+          push: true
+          tags: ${{ steps.meta-challenger.outputs.tags }}
+          labels: ${{ steps.meta-challenger.outputs.labels }}
+          platforms: |
+            linux/amd64
+            linux/arm64
+          cache-from: type=registry
+          cache-to: type=registry,mode=max

--- a/.github/workflows/docker-build-lite-celo.yaml
+++ b/.github/workflows/docker-build-lite-celo.yaml
@@ -61,7 +61,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: fault_proof/Dockerfile.proposer
+          file: fault-proof/Dockerfile.proposer
           push: true
           tags: ${{ steps.meta-proposer.outputs.tags }}
           labels: ${{ steps.meta-proposer.outputs.labels }}
@@ -75,7 +75,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: fault_proof/Dockerfile.challenger
+          file: fault-proof/Dockerfile.challenger
           push: true
           tags: ${{ steps.meta-challenger.outputs.tags }}
           labels: ${{ steps.meta-challenger.outputs.labels }}


### PR DESCRIPTION
This adds a CI build job on our self-hosted runners for the proposer and challenger images.
The images are built on `linux/amd64` and `linux/arm64` platforms. Unfortunately the [build job currently](https://github.com/celo-org/op-succinct/actions/runs/16196413478) takes around 4 1/2 hours, so there is room for improvement. Not building the `linux/arm64` (which is built with QEMU) could probably more than halve the build time, and using a runner with more compute might be appropriate.

For e.g. simple push events, the images can be found at e.g. `us-west1-docker.pkg.dev/blockchaintestsglobaltestnet/dev-images/op-succinct/proposer:sha-0669b0a` - a tag push with a semver tag will trigger a release tagged image.