### PR TITLE
Revert "fix: use eigenda feature in dockerfiles"

### DIFF
--- a/fault-proof/Dockerfile.challenger
+++ b/fault-proof/Dockerfile.challenger
@@ -38,7 +38,6 @@ RUN cargo build --release --bin challenger
 FROM ubuntu:24.04
 
 WORKDIR /app
-COPY resources/ ./resources/
 
 # Install only necessary runtime dependencies
 RUN apt-get update && apt-get install -y \

--- a/fault-proof/Dockerfile.proposer
+++ b/fault-proof/Dockerfile.proposer
@@ -38,7 +38,6 @@ RUN cargo build --release --bin proposer
 FROM ubuntu:24.04
 
 WORKDIR /app
-COPY resources/ ./resources/
 
 # Install only necessary runtime dependencies
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
This reverts changes that have been merged by https://github.com/celo-org/op-succinct/pull/8 .

Currently we haven't pulled in all EigenDA related commits into develop, including the addition of the `resources/g1.point` file. However the reverted commit was relying on the data being available in order to copy it into the docker-images filesystem.
Without the file being available the docker build fails. It also doesn't make sense right now to include the file, since the EigenDA features can't be used in this branch anyways.

