### PR TITLE
Fix for block fetch in merge latest upstream

### DIFF
--- a/utils/eigenda/host/src/host.rs
+++ b/utils/eigenda/host/src/host.rs
@@ -80,9 +80,6 @@ impl OPSuccinctHost for EigenDAOPSuccinctHost {
 
 impl EigenDAOPSuccinctHost {
     pub fn new(fetcher: Arc<OPSuccinctDataFetcher>) -> Self {
-        Self {
-            fetcher,
-            witness_generator: Arc::new(EigenDAWitnessGenerator {}),
-        }
+        Self { fetcher, witness_generator: Arc::new(EigenDAWitnessGenerator {}) }
     }
 }

--- a/utils/eigenda/host/src/host.rs
+++ b/utils/eigenda/host/src/host.rs
@@ -4,7 +4,7 @@ use alloy_eips::BlockId;
 use alloy_primitives::B256;
 use anyhow::Result;
 use async_trait::async_trait;
-use hokulea_host_bin::cfg::SingleChainHostWithEigenDA;
+use celo_host::single::CeloSingleChainHost;
 use op_succinct_host_utils::{fetcher::OPSuccinctDataFetcher, host::OPSuccinctHost};
 
 use crate::witness_generator::EigenDAWitnessGenerator;
@@ -17,7 +17,7 @@ pub struct EigenDAOPSuccinctHost {
 
 #[async_trait]
 impl OPSuccinctHost for EigenDAOPSuccinctHost {
-    type Args = SingleChainHostWithEigenDA;
+    type Args = CeloSingleChainHost;
     type WitnessGenerator = EigenDAWitnessGenerator;
 
     fn witness_generator(&self) -> &Self::WitnessGenerator {
@@ -30,7 +30,7 @@ impl OPSuccinctHost for EigenDAOPSuccinctHost {
         l2_end_block: u64,
         l1_head_hash: Option<B256>,
         safe_db_fallback: bool,
-    ) -> Result<SingleChainHostWithEigenDA> {
+    ) -> Result<CeloSingleChainHost> {
         // If l1_head_hash is not provided, calculate a safe L1 head
         let l1_head = match l1_head_hash {
             Some(hash) => hash,
@@ -42,7 +42,7 @@ impl OPSuccinctHost for EigenDAOPSuccinctHost {
         let host = self.fetcher.get_host_args(l2_start_block, l2_end_block, l1_head).await?;
 
         let eigenda_proxy_address = std::env::var("EIGENDA_PROXY_ADDRESS").ok();
-        Ok(SingleChainHostWithEigenDA { kona_cfg: host, eigenda_proxy_address, verbose: 1 })
+        Ok(CeloSingleChainHost { kona_cfg: host, eigenda_proxy_address, verbose: 1 })
     }
 
     fn get_l1_head_hash(&self, args: &Self::Args) -> Option<B256> {
@@ -80,6 +80,11 @@ impl OPSuccinctHost for EigenDAOPSuccinctHost {
 
 impl EigenDAOPSuccinctHost {
     pub fn new(fetcher: Arc<OPSuccinctDataFetcher>) -> Self {
-        Self { fetcher, witness_generator: Arc::new(EigenDAWitnessGenerator {}) }
+        Self {
+            fetcher,
+            witness_generator: Arc::new(EigenDAWitnessGenerator {
+                // executor: (), // Placeholder - will be created in witness_generator
+            }),
+        }
     }
 }

--- a/utils/eigenda/host/src/host.rs
+++ b/utils/eigenda/host/src/host.rs
@@ -82,9 +82,7 @@ impl EigenDAOPSuccinctHost {
     pub fn new(fetcher: Arc<OPSuccinctDataFetcher>) -> Self {
         Self {
             fetcher,
-            witness_generator: Arc::new(EigenDAWitnessGenerator {
-                // executor: (), // Placeholder - will be created in witness_generator
-            }),
+            witness_generator: Arc::new(EigenDAWitnessGenerator {}),
         }
     }
 }


### PR DESCRIPTION
This is just reverting a small part of what was merged in #19.

~~This solves the immediate problem of the cost estimator not being able to fetch blocks, but I guess this breaks the eigenda changes. So I'd consider this an intermediate step.~~

This seems to be a complete fix, since the `CeloSingleChainHost` embeds the `EigenDA functionality.

`@karlb I'm not sure what has happened on #19, there seem to be some extra commits from @Mc01 which are breaking things

Fixes https://github.com/celo-org/celo-blockchain-planning/issues/1236