### PR TITLE
Add tooling to build a forkdiff with diff to audit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ configs/
 **/codegen
 # Grafana alloy config
 config.alloy
+
+# Generated audit forkdiffs
+audits/audit-forkdiff.html

--- a/audits/audit-forkdiff.yaml
+++ b/audits/audit-forkdiff.yaml
@@ -1,5 +1,3 @@
-title: "protolambda's Greeter fork"  # Define the HTML page title
-logo: "logo.png"
 base:
   name: op-succinct
   url: https://github.com/succinctlabs/op-succinct
@@ -19,8 +17,8 @@ def:
       - ".gitignore"
       - ".gitmodules"
       - "**/Dockerfile*"
-# # files can be ignored globally, these will be listed in a separate grayed-out section,
-# # and do not count towards the total line count.
+# files can be ignored globally, these will be listed in a separate grayed-out section,
+# and do not count towards the total line count.
 ignore:
   - ".github/**"
   - ".env.example"

--- a/audits/audit-forkdiff.yaml
+++ b/audits/audit-forkdiff.yaml
@@ -1,0 +1,29 @@
+title: "protolambda's Greeter fork"  # Define the HTML page title
+logo: "logo.png"
+base:
+  name: op-succinct
+  url: https://github.com/succinctlabs/op-succinct
+  hash: fddb191a7c69408224027e6156d5effa36f351eb # Appears to be the most recent commit from upstream
+fork:
+  name: celo op-succinct
+  url: git@github.com:celo-org/op-succinct.git
+  ref: refs/heads/develop
+def:
+    title: "op-succinct Fork diff"
+    description: | # description in markdown
+      Displays a diff that can be used for auditing, "Other changes" and "Ignored changes" should not be included in the audit.
+    globs:
+      - "**/*.rs"
+      - "contracts/**"
+      - "**/Cargo.*"
+      - ".gitignore"
+      - ".gitmodules"
+      - "**/Dockerfile*"
+# # files can be ignored globally, these will be listed in a separate grayed-out section,
+# # and do not count towards the total line count.
+ignore:
+  - ".github/**"
+  - ".env.example"
+  - "CONTRIBUTING.md"
+  - "book/**"
+

--- a/justfile
+++ b/justfile
@@ -355,8 +355,12 @@ remove-config config_name env_file=".env":
 audit-forkdiff:
     #!/usr/bin/env bash
     set -euo pipefail
-
     outpath=audits/audit-forkdiff.html
-    go install github.com/protolambda/forkdiff@v0.1.1
-    forkdiff --repo . --fork audits/audit-forkdiff.yaml --out $outpath
+
+    docker run --rm \
+        --mount src=$(pwd),target=/host-pwd,type=bind \
+        --platform linux/amd64 \
+        protolambda/forkdiff:latest \
+        -repo /host-pwd/ -fork /host-pwd/audits/audit-forkdiff.yaml -out /host-pwd/$outpath
+
     echo "Audit forkdiff written to $outpath"

--- a/justfile
+++ b/justfile
@@ -351,3 +351,12 @@ remove-config config_name env_file=".env":
         --rpc-url $L1_RPC \
         --private-key $PRIVATE_KEY \
         --broadcast
+
+audit-forkdiff:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    outpath=audits/audit-forkdiff.html
+    go install github.com/protolambda/forkdiff@v0.1.1
+    forkdiff --repo . --fork audits/audit-forkdiff.yaml --out $outpath
+    echo "Audit forkdiff written to $outpath"


### PR DESCRIPTION
Running `just audit-forkdiff` will generate a forkdiff file showing the diff to be audited.

Relates to - https://github.com/celo-org/celo-blockchain-planning/issues/1241