### PR TITLE
Fix: differentiate the case when canoe proof is None or eigenda_data is None

### DIFF
--- a/programs/range/eigenda/src/main.rs
+++ b/programs/range/eigenda/src/main.rs
@@ -30,22 +30,16 @@ fn main() {
             .expect("Failed to deserialize witness data.");
 
         let (oracle, _beacon) = witness_data.clone().get_oracle_and_blob_provider().await.unwrap();
-
-        let preloaded_blob_provider = match &witness_data.eigenda_data {
-            Some(eigenda_witness_bytes) => {
-                let eigenda_witness: EigenDABlobWitnessData = serde_cbor::from_slice(
-                    &eigenda_witness_bytes.clone(),
-                )
-                .expect("cannot deserialize eigenda witness");
-                let preloaded_blob_provider =
-                    eigenda_witness_to_preloaded_provider(oracle, CanoeSp1CCVerifier {}, eigenda_witness)
-                        .await
-                        .expect("Failed to get preloaded blob provider");
-                preloaded_blob_provider
-            },
-            // when no preimage (recency, validity or encoded payload) is required to run Hokulea
-            None => PreloadedEigenDABlobProvider::default(),
-        };
+        
+        let eigenda_witness: EigenDABlobWitnessData = serde_cbor::from_slice(
+            &witness_data.eigenda_data.clone().expect("eigenda witness data is not present"),
+        )
+        .expect("cannot deserialize eigenda witness");
+    
+        let preloaded_blob_provider =
+            eigenda_witness_to_preloaded_provider(oracle, CanoeSp1CCVerifier {}, eigenda_witness)
+                .await
+                .expect("Failed to get preloaded blob provider");
 
         run_range_program(EigenDAWitnessExecutor::new(preloaded_blob_provider), witness_data).await;
     });

--- a/programs/range/eigenda/src/main.rs
+++ b/programs/range/eigenda/src/main.rs
@@ -10,7 +10,7 @@
 sp1_zkvm::entrypoint!(main);
 
 use hokulea_proof::{
-    canoe_verifier::sp1_cc::CanoeSp1CCVerifier, eigenda_blob_witness::EigenDABlobWitnessData,
+    canoe_verifier::sp1_cc::CanoeSp1CCVerifier, eigenda_blob_witness::EigenDABlobWitnessData, preloaded_eigenda_provider::PreloadedEigenDABlobProvider,
 };
 use hokulea_zkvm_verification::eigenda_witness_to_preloaded_provider;
 use op_succinct_client_utils::witness::{EigenDAWitnessData, WitnessData};
@@ -30,14 +30,22 @@ fn main() {
             .expect("Failed to deserialize witness data.");
 
         let (oracle, _beacon) = witness_data.clone().get_oracle_and_blob_provider().await.unwrap();
-        let eigenda_witness: EigenDABlobWitnessData = serde_cbor::from_slice(
-            &witness_data.eigenda_data.clone().expect("eigenda witness data is not present"),
-        )
-        .expect("cannot deserialize eigenda witness");
-        let preloaded_blob_provider =
-            eigenda_witness_to_preloaded_provider(oracle, CanoeSp1CCVerifier {}, eigenda_witness)
-                .await
-                .expect("Failed to get preloaded blob provider");
+
+        let preloaded_blob_provider = match &witness_data.eigenda_data {
+            Some(eigenda_witness_bytes) => {
+                let eigenda_witness: EigenDABlobWitnessData = serde_cbor::from_slice(
+                    &eigenda_witness_bytes.clone(),
+                )
+                .expect("cannot deserialize eigenda witness");
+                let preloaded_blob_provider =
+                    eigenda_witness_to_preloaded_provider(oracle, CanoeSp1CCVerifier {}, eigenda_witness)
+                        .await
+                        .expect("Failed to get preloaded blob provider");
+                preloaded_blob_provider
+            },
+            // when no preimage (recency, validity or encoded payload) is required to run Hokulea
+            None => PreloadedEigenDABlobProvider::default(),
+        };
 
         run_range_program(EigenDAWitnessExecutor::new(preloaded_blob_provider), witness_data).await;
     });

--- a/utils/eigenda/host/src/witness_generator.rs
+++ b/utils/eigenda/host/src/witness_generator.rs
@@ -144,8 +144,9 @@ impl WitnessGenerator for EigenDAWitnessGenerator {
         // Extract the EigenDA witness data
         let mut eigenda_witness_data = std::mem::take(&mut *eigenda_blobs_witness.lock().unwrap());
 
-        // If there are no EigenDA DA certs collected for this range, skip Canoe proof generation.
-        if eigenda_witness_data.validity.is_empty() {
+        // If no Hokulea preimage is required, then eigenda_data should be None
+        // (Todo), EigenDABlobWitness should expose a function, as opposed to check is_empty()
+        if eigenda_witness_data.recency.is_empty() {
             let witness = EigenDAWitnessData {
                 preimage_store: preimage_witness_store.lock().unwrap().clone(),
                 blob_data: blob_data.lock().unwrap().clone(),
@@ -155,27 +156,32 @@ impl WitnessGenerator for EigenDAWitnessGenerator {
             return Ok(witness);
         }
 
-        // Generate canoe proofs using the reduced proof provider for proof aggregation
-        use canoe_sp1_cc_host::CanoeSp1CCReducedProofProvider;
-        let eth_rpc_url = std::env::var("L1_RPC")
-            .map_err(|_| anyhow::anyhow!("L1_RPC environment variable not set"))?;
-        let mock_mode = env::var("OP_SUCCINCT_MOCK")
-            .unwrap_or("false".to_string())
-            .parse::<bool>()
-            .unwrap_or(false);
-        let canoe_provider = CanoeSp1CCReducedProofProvider { eth_rpc_url, mock_mode };
-        let canoe_proofs = hokulea_witgen::from_boot_info_to_canoe_proof(
-            &boot_info,
-            &eigenda_witness_data,
-            oracle.clone(),
-            canoe_provider,
-        )
-        .await?;
+        // If there is no da cert, skip Canoe proof generation
+        if eigenda_witness_data.require_canoe_proof() {
+             // Generate canoe proofs using the reduced proof provider for proof aggregation
+            use canoe_sp1_cc_host::CanoeSp1CCReducedProofProvider;
+            let eth_rpc_url = std::env::var("L1_RPC")
+                .map_err(|_| anyhow::anyhow!("L1_RPC environment variable not set"))?;
+            let mock_mode = env::var("OP_SUCCINCT_MOCK")
+                .unwrap_or("false".to_string())
+                .parse::<bool>()
+                .unwrap_or(false);
+            let canoe_provider = CanoeSp1CCReducedProofProvider { eth_rpc_url, mock_mode };
+            let canoe_proofs = hokulea_witgen::from_boot_info_to_canoe_proof(
+                &boot_info,
+                &eigenda_witness_data,
+                oracle.clone(),
+                canoe_provider,
+            )
+            .await?;
 
-        // Store the canoe proof in the witness data
-        let canoe_proof_bytes =
-            serde_cbor::to_vec(&canoe_proofs).expect("Failed to serialize canoe proof");
-        eigenda_witness_data.canoe_proof_bytes = Some(canoe_proof_bytes);
+            // Store the canoe proof in the witness data
+            let canoe_proof_bytes =
+                serde_cbor::to_vec(&canoe_proofs).expect("Failed to serialize canoe proof");
+            eigenda_witness_data.canoe_proof_bytes = Some(canoe_proof_bytes);
+        } else {
+            eigenda_witness_data.canoe_proof_bytes = None
+        }
 
         let eigenda_witness_bytes = serde_cbor::to_vec(&eigenda_witness_data)
             .expect("Failed to serialize EigenDA witness data");

--- a/utils/eigenda/host/src/witness_generator.rs
+++ b/utils/eigenda/host/src/witness_generator.rs
@@ -144,43 +144,29 @@ impl WitnessGenerator for EigenDAWitnessGenerator {
         // Extract the EigenDA witness data
         let mut eigenda_witness_data = std::mem::take(&mut *eigenda_blobs_witness.lock().unwrap());
 
-        // If no Hokulea preimage is required, then eigenda_data should be None
-        // (Todo), EigenDABlobWitness should expose a function, as opposed to check is_empty()
-        if eigenda_witness_data.recency.is_empty() {
-            let witness = EigenDAWitnessData {
-                preimage_store: preimage_witness_store.lock().unwrap().clone(),
-                blob_data: blob_data.lock().unwrap().clone(),
-                eigenda_data: None,
-            };
 
-            return Ok(witness);
-        }
+            // Generate canoe proofs using the reduced proof provider for proof aggregation
+        use canoe_sp1_cc_host::CanoeSp1CCReducedProofProvider;
+        let eth_rpc_url = std::env::var("L1_RPC")
+            .map_err(|_| anyhow::anyhow!("L1_RPC environment variable not set"))?;
+        let mock_mode = env::var("OP_SUCCINCT_MOCK")
+            .unwrap_or("false".to_string())
+            .parse::<bool>()
+            .unwrap_or(false);
+        let canoe_provider = CanoeSp1CCReducedProofProvider { eth_rpc_url, mock_mode };
+        let canoe_proofs = hokulea_witgen::from_boot_info_to_canoe_proof(
+            &boot_info,
+            &eigenda_witness_data,
+            oracle.clone(),
+            canoe_provider,
+        )
+        .await?;
 
-        // If there is no da cert, skip Canoe proof generation
-        if eigenda_witness_data.require_canoe_proof() {
-             // Generate canoe proofs using the reduced proof provider for proof aggregation
-            use canoe_sp1_cc_host::CanoeSp1CCReducedProofProvider;
-            let eth_rpc_url = std::env::var("L1_RPC")
-                .map_err(|_| anyhow::anyhow!("L1_RPC environment variable not set"))?;
-            let mock_mode = env::var("OP_SUCCINCT_MOCK")
-                .unwrap_or("false".to_string())
-                .parse::<bool>()
-                .unwrap_or(false);
-            let canoe_provider = CanoeSp1CCReducedProofProvider { eth_rpc_url, mock_mode };
-            let canoe_proofs = hokulea_witgen::from_boot_info_to_canoe_proof(
-                &boot_info,
-                &eigenda_witness_data,
-                oracle.clone(),
-                canoe_provider,
-            )
-            .await?;
-
+        if let Some(proof) = canoe_proofs {
             // Store the canoe proof in the witness data
             let canoe_proof_bytes =
                 serde_cbor::to_vec(&canoe_proofs).expect("Failed to serialize canoe proof");
             eigenda_witness_data.canoe_proof_bytes = Some(canoe_proof_bytes);
-        } else {
-            eigenda_witness_data.canoe_proof_bytes = None
         }
 
         let eigenda_witness_bytes = serde_cbor::to_vec(&eigenda_witness_data)


### PR DESCRIPTION
EigenDA blob derivation requires multiple types of preimage sources:
- recencies: Vec<>
- validities: Vec<>
- encoded_payloads: Vec<>
there is a relation that recencies.len() >= validities.len() >= encoded_payloads.len()

If there is no recency preimage at all, then we learn there is no preimage requirement for Hokulea

If there is no validity preimage, then we don't need to prepare the canoe proof