### PR TITLE
Fix refactored proposer to handle game type transition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ contracts/opsuccinctfdgconfig.json
 
 # Rollup Configs
 configs/
+!fault-proof/configs/
 
 # Contract Bindings
 **/codegen

--- a/fault-proof/Dockerfile.proposer
+++ b/fault-proof/Dockerfile.proposer
@@ -40,6 +40,10 @@ FROM ubuntu:24.04
 WORKDIR /app
 COPY resources/ ./resources/
 
+# Create configs directories and copy pre-existing configs from fault-proof/configs/ for custom L1 (local devnet)
+RUN mkdir -p ./configs/L1
+COPY --from=builder /usr/src/app/fault-proof/configs/L1/ ./configs/L1/
+
 # Install only necessary runtime dependencies
 RUN apt-get update && apt-get install -y \
     curl \

--- a/fault-proof/configs/L1/3151908.json
+++ b/fault-proof/configs/L1/3151908.json
@@ -1,0 +1,31 @@
+{
+   "config": {
+        "chainId": 3151908,
+        "homesteadBlock": 0,
+        "daoForkBlock": 0,
+        "daoForkSupport": true,
+        "eip150Block": 0,
+        "eip155Block": 0,
+        "eip158Block": 0,
+        "byzantiumBlock": 0,
+        "constantinopleBlock": 0,
+        "petersburgBlock": 0,
+        "istanbulBlock": 0,
+        "muirGlacierBlock": 0,
+        "berlinBlock": 0,
+        "londonBlock": 0,
+        "mergeNetsplitBlock": 0,
+        "terminalTotalDifficulty": "0",
+        "shanghaiTime": 0,
+        "cancunTime": 0,
+        "pragueTime": 0
+   },
+  "coinbase": "0x0000000000000000000000000000000000000000",
+  "difficulty": "0x01",
+  "extraData": "",
+  "gasLimit": "0x17D7840",
+  "nonce": "0x1234",
+  "mixhash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "timestamp": "1695902100"
+}


### PR DESCRIPTION
Small fixes to the proposer, to filter out all other type games when syncing games. Previously, the proposer skipped any game whose parent was not found in its state. But during a game type transition, the proposer needs to track the first type 42 game in order to create subsequent games and continue tracking all type 42 games. So a special case was added so that the first type 42 game is not filtered out even if its parent is missing in the state.
With this fix, the proposer can now handle game type transition as long as the first type 42 game is created manually.

Also added devnet L1 config.json file so that the proposer binary can include it for local devnet use.