### PR TITLE
Change aggregation proof mode to plonk

### DIFF
--- a/fault-proof/src/proposer.rs
+++ b/fault-proof/src/proposer.rs
@@ -630,7 +630,7 @@ where
             self.prover
                 .network_prover
                 .prove(&self.prover.agg_pk, &sp1_stdin)
-                .groth16()
+                .plonk()
                 .strategy(self.config.agg_proof_strategy)
                 .timeout(Duration::from_secs(self.config.timeout))
                 .min_auction_period(self.config.min_auction_period)


### PR DESCRIPTION
We want to change the aggregation proof mode from Groth16 to Plonk which is more secure. But currently the proposer doesn't support the mode customization. So temporarily change it to plonk, later we need to make it configurable with the flag `AGG_PROOF_MODE`.