### PR TITLE
Fix push-container CI for release and re-enable trivy checks

### DIFF
--- a/.github/workflows/push-container.yaml
+++ b/.github/workflows/push-container.yaml
@@ -49,7 +49,7 @@ jobs:
         && inputs.concurrency-group
         || format('{0}-{1}', github.workflow, (github.head_ref != '' && github.head_ref || github.ref)) }}
       cancel-in-progress: true
-    uses: celo-org/reusable-workflows/.github/workflows/docker-build.yaml@v3.1.0-rc.1
+    uses: celo-org/reusable-workflows/.github/workflows/docker-build.yaml@v3.1.0-rc.3
     with:
       runs-on: '["self-hosted", "org", "8-cpu"]'
       workload-id-provider: ${{ inputs.workload-id-provider }}

--- a/.github/workflows/push-container.yaml
+++ b/.github/workflows/push-container.yaml
@@ -35,6 +35,8 @@ jobs:
             type=edge
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha
+            # pull request event
+            type=ref,event=pr
   build_push_container:
     needs: infer_image_metadata
     permissions:

--- a/.github/workflows/push-container.yaml
+++ b/.github/workflows/push-container.yaml
@@ -31,7 +31,7 @@ jobs:
         with:
           images: ${{ inputs.artifact-registry }}
           tags: |
-            type=semver,pattern={{version}}
+            type=semver,pattern={{version}},match=celo/v(.*)
             type=edge
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha

--- a/.github/workflows/push-container.yaml
+++ b/.github/workflows/push-container.yaml
@@ -60,5 +60,4 @@ jobs:
       context: .
       file: ${{ inputs.file }}
       tags: ${{ needs.infer_image_metadata.outputs.tags }}
-      #TODO: re-enable, once multiple image scans per workflow are possible via groups
-      trivy-enabled: false
+      trivy-enabled: true


### PR DESCRIPTION
This relies on the `reusable-workflows@3.1.0-rc.3` version. 
The fixes for the release workflow itself have not been tested yet, but I did not want to create a release just for testing purposes. Rather, we should cut the next `rc` build as soon as this PR and our current fixes are merged into develop and try it out like that.

