### PR TITLE
Log SP1 stdin size in multi, cost-estimator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9147,6 +9147,7 @@ version = "3.3.3-b"
 dependencies = [
  "alloy-primitives",
  "anyhow",
+ "bincode",
  "cargo_metadata",
  "cfg-if",
  "clap",

--- a/scripts/prove/Cargo.toml
+++ b/scripts/prove/Cargo.toml
@@ -41,6 +41,7 @@ alloy-primitives.workspace = true
 sp1-sdk.workspace = true
 
 rustls = { version = "0.23.23", features = ["ring"] }
+bincode.workspace = true
 
 [dev-dependencies]
 reqwest = { version = "0.12.4", features = ["json"] }

--- a/scripts/prove/bin/multi.rs
+++ b/scripts/prove/bin/multi.rs
@@ -11,7 +11,7 @@ use op_succinct_proof_utils::{get_range_elf_embedded, initialize_host};
 use op_succinct_prove::{execute_multi, DEFAULT_RANGE};
 use op_succinct_scripts::HostExecutorArgs;
 use sp1_sdk::{utils, Prover, ProverClient};
-use tracing::debug;
+use tracing::{debug, info};
 
 /// Execute the OP Succinct program for multiple blocks.
 #[tokio::main]
@@ -49,6 +49,9 @@ async fn main() -> Result<()> {
 
     // Get the stdin for the block.
     let sp1_stdin = host.witness_generator().get_sp1_stdin(witness_data)?;
+    let stdin_bytes = bincode::serialize(&sp1_stdin).unwrap();
+    let stdin_len = stdin_bytes.len();
+    info!("Generated SP1 stdin for blocks {l2_start_block} to {l2_end_block}, number: {:?}, size: {stdin_len} bytes", l2_end_block - l2_start_block);
 
     if args.prove {
         // If the prove flag is set, generate a proof.


### PR DESCRIPTION
It'd be useful to get some data on the SP1 zkVM stdin size depending on the block range size when running multi and cost-estimator. Note that cost-estimator will log the stdin size for each sub-range. Also modified the cost-estimator to panic when any sub-range failed to execute.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Logs SP1 stdin size in multi and cost estimator, adds bincode, and makes execution failures hard-fail with error + panic.
> 
> - **Proving/scripts**:
>   - Log SP1 stdin size in `scripts/prove/bin/multi.rs` by serializing stdin with `bincode`; add `tracing::info` usage.
>   - Add `bincode` dependency in `scripts/prove/Cargo.toml` (and lockfile).
> - **Cost estimator** (`scripts/utils/bin/cost_estimator.rs`):
>   - Log SP1 stdin size per block range via `bincode` serialization.
>   - Tighten error handling: change execution failure log from `warn` to `error` and `panic!` on failure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 799cdee5cb7608ebc8702a67fa7d36cab970fdb0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->