### PR TITLE
chore(ci): tag release images with additional major tag `v{{major}}`

### DIFF
--- a/.github/workflows/push-container.yaml
+++ b/.github/workflows/push-container.yaml
@@ -32,6 +32,7 @@ jobs:
           images: ${{ inputs.artifact-registry }}
           tags: |
             type=semver,pattern={{version}},match=celo/v(.*)
+            type=semver,pattern=v{{major}},match=celo/v(\d+\.\d+\.\d+)$
             type=edge
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha


### PR DESCRIPTION
This will add a major-release tag to "release" type docker images for production releases.

E.g. the built docker image from release tag `celo/v1.2.3` will then not only be tagged with `v1.2.3`, but also with `v1`.
This is a convenience feature so that we don't have to remember updating e.g. default challenger/proposer tags in our docker-compose setup whenever there is a bug-fix or feature release.

Note, that this requires us to be disciplined with breaking changes and complying to semver semantics, even though we haven't formally defined a public API.