### PR TITLE
Add prove-dryrun script

### DIFF
--- a/.env.example.prove_dryrun
+++ b/.env.example.prove_dryrun
@@ -1,0 +1,16 @@
+L1_RPC=https://                 # L1 execution node RPC URL
+L1_BEACON_RPC=https://          # L1 consensus node RPC URL
+L2_RPC=https://                 # L2 execution node RPC URL
+L2_NODE_RPC=https://            # L2 consensus node RPC URL 
+EIGENDA_PROXY_ADDRESS=https://  # Eigen DA proxy URL
+
+USE_KMS_REQUESTER=false         # Whether to expect NETWORK_PRIVATE_KEY to be an AWS KMS key ARN instead of a plaintext private key
+NETWORK_PRIVATE_KEY=0x          # Succinct Prover Network private key
+RANGE_PROOF_STRATEGY=reserved   # Proof strategy for Range Proof (default: reserved)
+AGG_PROOF_STRATEGY=reserved     # Proof strategy for Aggregation Proof (default: reserved)
+AGG_PROOF_MODE=plonk            # Proof mode for Aggregation Proof (default: plonk)
+
+FACTORY_ADDRESS=                # Dispute Game Factory Address
+GAME_TYPE=42                    # OP Succinct Fault Dispute Game Type
+PROPOSER_ADDRESS=               # Proposer Address
+PRIVATE_KEY=0x                  # Transaction Signer Private Key (Funded account on L1 or Anvil)

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ data
 
 # .env files
 .env*
-!.env.example
+!.env.example*
 
 # txt
 **.txt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
  "crypto-common",
- "generic-array 0.14.9",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -122,9 +122,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01db470290bb814e0485fa79aba6e36bb5d221c2e3cfeba5fba05a8a2ca8dad"
+checksum = "9e15860af634cad451f598712c24ca7fd9b45d84fff68ab8d4967567fa996c64"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -161,9 +161,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.17"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6068f356948cd84b5ad9ac30c50478e433847f14a50714d2b68f15d052724049"
+checksum = "4bc32535569185cbcb6ad5fa64d989a47bccb9a08e27284b1f2a3ccf16e6d010"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -174,9 +174,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90d103d3e440ad6f703dd71a5b58a6abd24834563bde8a5fabe706e00242f810"
+checksum = "8b6440213a22df93a87ed512d2f668e7dc1d62a05642d107f82d61edc9e12370"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -185,6 +185,7 @@ dependencies = [
  "alloy-trie",
  "alloy-tx-macros",
  "auto_impl",
+ "borsh",
  "c-kzg",
  "derive_more 2.0.1",
  "either",
@@ -200,9 +201,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48ead76c8c84ab3a50c31c56bc2c748c2d64357ad2131c32f9b10ab790a25e1a"
+checksum = "15d0bea09287942405c4f9d2a4f22d1e07611c2dbd9d5bf94b75366340f9e6e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -214,9 +215,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5903097e4c131ad2dd80d87065f23c715ccb9cdb905fa169dffab8e1e798bae"
+checksum = "d69af404f1d00ddb42f2419788fa87746a4cd13bab271916d7726fda6c792d94"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -305,9 +306,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bdbec74583d0067798d77afa43d58f00d93035335d7ceaa5d3f93857d461bb9"
+checksum = "4bd2c7ae05abcab4483ce821f12f285e01c0b33804e6883dd9ca1569a87ee2be"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -316,6 +317,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "auto_impl",
+ "borsh",
  "c-kzg",
  "derive_more 2.0.1",
  "either",
@@ -329,9 +331,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.23.1"
+version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "428b58c17ab5f9f71765dc5f116acb6580f599ce243b8ce391de3ba859670c61"
+checksum = "527b47dc39850c6168002ddc1f7a2063e15d26137c1bb5330f6065a7524c1aa9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -352,14 +354,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c25d5acb35706e683df1ea333c862bdb6b7c5548836607cd5bb56e501cca0b4f"
+checksum = "fc47eaae86488b07ea8e20236184944072a78784a1f4993f8ec17b3aa5d08c21"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-serde",
  "alloy-trie",
+ "borsh",
  "serde",
  "serde_with",
 ]
@@ -405,13 +408,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31b67c5a702121e618217f7a86f314918acb2622276d0273490e2d4534490bc0"
+checksum = "003f46c54f22854a32b9cc7972660a476968008ad505427eabab49225309ec40"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
- "http 1.3.1",
+ "http 1.4.0",
  "serde",
  "serde_json",
  "thiserror 2.0.17",
@@ -420,9 +423,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612296e6b723470bb1101420a73c63dfd535aa9bf738ce09951aedbd4ab7292e"
+checksum = "4f4029954d9406a40979f3a3b46950928a0fdcfe3ea8a9b0c17490d57e8aa0e3"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -446,9 +449,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0e7918396eecd69d9c907046ec8a93fb09b89e2f325d5e7ea9c4e3929aa0dd2"
+checksum = "7805124ad69e57bbae7731c9c344571700b2a18d351bda9e0eba521c991d1bcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -459,9 +462,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-node-bindings"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0be31900cc96fede4dc888a100f3c28fa2d22093f8e09fb7992829ce886acc2f"
+checksum = "b03d35475a02d2a8b76209cb4a1336cb7d85331d10a0f6ec329ee42151695c19"
 dependencies = [
  "alloy-genesis",
  "alloy-hardforks 0.2.13",
@@ -480,9 +483,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-op-evm"
-version = "0.23.1"
+version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaa49899e2b0e59a5325e2042a6c5bd4c17e1255fce1e66a9312816f52e886f1"
+checksum = "6eea81517a852d9e3b03979c10febe00aacc3d50fbd34c5c30281051773285f7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -522,8 +525,8 @@ dependencies = [
  "derive_more 2.0.1",
  "foldhash 0.2.0",
  "getrandom 0.3.4",
- "hashbrown 0.16.0",
- "indexmap 2.12.0",
+ "hashbrown 0.16.1",
+ "indexmap 2.12.1",
  "itoa",
  "k256 0.13.4",
  "keccak-asm",
@@ -539,9 +542,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55c1313a527a2e464d067c031f3c2ec073754ef615cc0eabca702fd0fe35729c"
+checksum = "d369e12c92870d069e0c9dc5350377067af8a056e29e3badf8446099d7e00889"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -584,9 +587,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "810766eeed6b10ffa11815682b3f37afc5019809e3b470b23555297d5770ce63"
+checksum = "f77d20cdbb68a614c7a86b3ffef607b37d087bb47a03c58f4c3f8f99bc3ace3b"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -623,14 +626,14 @@ checksum = "64b728d511962dda67c1bc7ea7c03736ec275ed2cf4c35d9585298ac9ccf3b73"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45f802228273056528dfd6cc8845cc91a7c7e0c6fc1a66d19e8673743dacdc7e"
+checksum = "31c89883fe6b7381744cbe80fef638ac488ead4f1956a4278956a1362c71cd2e"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -654,9 +657,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ff3df608dcabd6bdd197827ff2b8faaa6cefe0c462f7dc5e74108666a01f56"
+checksum = "64e279e6d40ee40fe8f76753b678d8d5d260cb276dc6c8a8026099b16d2b43f4"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-debug",
@@ -667,9 +670,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdbf6d1766ca41e90ac21c4bc5cbc5e9e965978a25873c3f90b3992d905db4cb"
+checksum = "b43c1622aac2508d528743fd4cfdac1dea92d5a8fa894038488ff7edd0af0b32"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -678,9 +681,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab94e446a003dcef86843eea60d05a6cec360eb8e1829e4cf388ef94d799b5cf"
+checksum = "1786681640d4c60f22b6b8376b0f3fa200360bf1c3c2cb913e6c97f51928eb1b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -694,9 +697,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "977698b458738369ba5ca645d2cdb4d51ba07a81db37306ff85322853161ea3a"
+checksum = "1b2ca3a434a6d49910a7e8e51797eb25db42ef8a5578c52d877fcb26d0afe7bc"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.0.1",
@@ -706,9 +709,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07da696cc7fbfead4b1dda8afe408685cae80975cbb024f843ba74d9639cd0d3"
+checksum = "d9c4c53a8b0905d931e7921774a1830609713bd3e8222347963172b03a3ecc68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -726,9 +729,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a15e4831b71eea9d20126a411c1c09facf1d01d5cac84fd51d532d3c429cfc26"
+checksum = "ed5fafb741c19b3cca4cdd04fa215c89413491f9695a3e928dee2ae5657f607e"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -747,9 +750,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb0c800e2ce80829fca1491b3f9063c29092850dc6cf19249d5f678f0ce71bb0"
+checksum = "c55324323aa634b01bdecb2d47462a8dce05f5505b14a6e5db361eef16eda476"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -761,9 +764,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "751d1887f7d202514a82c5b3caf28ee8bd4a2ad9549e4f498b6f0bff99b52add"
+checksum = "a6f180c399ca7c1e2fe17ea58343910cad0090878a696ff5a50241aee12fc529"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -772,9 +775,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf0b42ffbf558badfecf1dde0c3c5ed91f29bb7e97876d0bed008c3d5d67171"
+checksum = "ecc39ad2c0a3d2da8891f4081565780703a593f090f768f884049aa3aa929cbc"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -787,9 +790,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-aws"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6b73b812ab342d09de85eb302598a3a0c4d744cbe982ed76e309dcec9ddfa"
+checksum = "75411104af460ca0b306ae998f0a00b5159457780487630f4b24722beae6b690"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -806,9 +809,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-gcp"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba2bd8fcc42b831aa219deac7a0b642eb418446a402a4de3b302c6e9ad09702c"
+checksum = "fcd808e99893245e619babcc138af07191ded72dc42877e216006b1ebcae64a7"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -824,9 +827,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e7d555ee5f27be29af4ae312be014b57c6cff9acb23fe2cf008500be6ca7e33"
+checksum = "930e17cb1e46446a193a593a3bfff8d0ecee4e510b802575ebe300ae2e43ef75"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -849,7 +852,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -862,11 +865,11 @@ dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
  "heck 0.5.0",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
  "syn-solidity",
  "tiny-keccak",
 ]
@@ -885,7 +888,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.109",
+ "syn 2.0.111",
  "syn-solidity",
 ]
 
@@ -913,9 +916,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71b3deee699d6f271eab587624a9fa84d02d0755db7a95a043d52a6488d16ebe"
+checksum = "cae82426d98f8bc18f53c5223862907cac30ab8fc5e4cd2bb50808e6d3ab43d8"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -936,15 +939,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1720bd2ba8fe7e65138aca43bb0f680e4e0bcbd3ca39bf9d3035c9d7d2757f24"
+checksum = "90aa6825760905898c106aba9c804b131816a15041523e80b6d4fe7af6380ada"
 dependencies = [
  "alloy-json-rpc",
  "alloy-rpc-types-engine",
  "alloy-transport",
  "http-body-util",
- "hyper 1.7.0",
+ "hyper 1.8.1",
  "hyper-tls 0.6.0",
  "hyper-util",
  "jsonwebtoken",
@@ -957,9 +960,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea89c214c7ddd2bcad100da929d6b642bbfed85788caf3b1be473abacd3111f9"
+checksum = "6ace83a4a6bb896e5894c3479042e6ba78aa5271dde599aa8c36a021d49cc8cc"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -977,14 +980,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "571aadf0afce0d515a28b2c6352662a39cb9f48b4eeff9a5c34557d6ea126730"
+checksum = "86c9ab4c199e3a8f3520b60ba81aa67bb21fed9ed0d8304e0569094d0758a56f"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
  "futures",
- "http 1.3.1",
+ "http 1.4.0",
  "rustls 0.23.35",
  "serde_json",
  "tokio",
@@ -1011,14 +1014,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd7ce8ed34106acd6e21942022b6a15be6454c2c3ead4d76811d3bdcd63cf771"
+checksum = "ae109e33814b49fc0a62f2528993aa8a2dd346c26959b151f05441dc0b9da292"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1071,22 +1074,22 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.10"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1227,7 +1230,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1265,7 +1268,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1356,7 +1359,7 @@ checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1429,7 +1432,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
  "synstructure 0.13.2",
 ]
 
@@ -1441,7 +1444,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1464,9 +1467,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.32"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a89bce6054c720275ac2432fbba080a66a2106a44a1b804553930ca6909f4e0"
+checksum = "0e86f6d3dc9dc4352edeea6b8e499e13e3f5dc3b964d7ca5fd411415a3498473"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -1512,7 +1515,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1523,7 +1526,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1572,7 +1575,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16e2cdb6d5ed835199484bb92bb8b3edd526effe995c61732580439c1a67e2e9"
 dependencies = [
  "base64 0.22.1",
- "http 1.3.1",
+ "http 1.4.0",
  "log",
  "url",
 ]
@@ -1595,7 +1598,7 @@ checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1606,9 +1609,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-config"
-version = "1.8.10"
+version = "1.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1856b1b48b65f71a4dd940b1c0931f9a7b646d4a924b9828ffefc1454714668a"
+checksum = "a0149602eeaf915158e14029ba0c78dedb8c08d554b024d54c8f239aab46511d"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1625,7 +1628,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "hex",
- "http 1.3.1",
+ "http 1.4.0",
  "ring",
  "time",
  "tokio",
@@ -1636,9 +1639,9 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.8"
+version = "1.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf26925f4a5b59eb76722b63c2892b1d70d06fa053c72e4a100ec308c1d47bc"
+checksum = "b01c9521fa01558f750d183c8c68c81b0155b9d193a4ba7f84c36bd1b6d04a06"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -1648,9 +1651,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.14.1"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879b6c89592deb404ba4dc0ae6b58ffd1795c78991cbb5b8bc441c48a070440d"
+checksum = "6b5ce75405893cd713f9ab8e297d8e438f624dde7d706108285f7e17a25a180f"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -1658,11 +1661,10 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.32.3"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "107a4e9d9cab9963e04e84bb8dee0e25f2a987f9a8bad5ed054abd439caa8f8c"
+checksum = "179c3777a8b5e70e90ea426114ffc565b2c1a9f82f6c4a0c5a34aa6ef5e781b6"
 dependencies = [
- "bindgen 0.72.1",
  "cc",
  "cmake",
  "dunce",
@@ -1671,9 +1673,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.5.13"
+version = "1.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f2402da1a5e16868ba98725e5d73f26b8116eaa892e56f2cd0bf5eec7985f70"
+checksum = "7ce527fb7e53ba9626fc47824f25e256250556c40d8f81d27dd92aa38239d632"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -1695,9 +1697,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kms"
-version = "1.92.0"
+version = "1.96.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0b4c5b673a7c76c831a707461eb9fdc880c54f47fa61ffe322fd8cfc59b3e4a"
+checksum = "995d40070271994fb774137aa603c10e7d29c4567a9605c6b801dff199c3d221"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1717,9 +1719,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.88.0"
+version = "1.90.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05b276777560aa9a196dbba2e3aada4d8006d3d7eeb3ba7fe0c317227d933c4"
+checksum = "4f18e53542c522459e757f81e274783a78f8c81acdfc8d1522ee8a18b5fb1c66"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1739,9 +1741,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.90.0"
+version = "1.92.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9be14d6d9cd761fac3fd234a0f47f7ed6c0df62d83c0eeb7012750e4732879b"
+checksum = "532f4d866012ffa724a4385c82e8dd0e59f0ca0e600f3f22d4c03b6824b34e4a"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1761,9 +1763,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.90.0"
+version = "1.94.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98a862d704c817d865c8740b62d8bbeb5adcb30965e93b471df8a5bcefa20a80"
+checksum = "1be6fbbfa1a57724788853a623378223fe828fc4c09b146c992f0c95b6256174"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1797,7 +1799,7 @@ dependencies = [
  "hex",
  "hmac",
  "http 0.2.12",
- "http 1.3.1",
+ "http 1.4.0",
  "percent-encoding",
  "sha2 0.10.9",
  "time",
@@ -1828,7 +1830,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 0.2.12",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 0.4.6",
  "percent-encoding",
  "pin-project-lite",
@@ -1848,10 +1850,10 @@ dependencies = [
  "h2 0.3.27",
  "h2 0.4.12",
  "http 0.2.12",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 0.4.6",
  "hyper 0.14.32",
- "hyper 1.7.0",
+ "hyper 1.8.1",
  "hyper-rustls 0.24.2",
  "hyper-rustls 0.27.7",
  "hyper-util",
@@ -1909,7 +1911,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "pin-project-lite",
@@ -1928,7 +1930,7 @@ dependencies = [
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
- "http 1.3.1",
+ "http 1.4.0",
  "pin-project-lite",
  "tokio",
  "tracing",
@@ -1946,7 +1948,7 @@ dependencies = [
  "bytes-utils",
  "futures-core",
  "http 0.2.12",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "http-body-util",
@@ -2022,10 +2024,10 @@ dependencies = [
  "axum-core 0.4.5",
  "bytes",
  "futures-util",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.7.0",
+ "hyper 1.8.1",
  "hyper-util",
  "itoa",
  "matchit 0.7.3",
@@ -2048,14 +2050,14 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18ed336352031311f4e0b4dd2ff392d4fbb370777c9d18d7fc9d7359f73871"
+checksum = "5b098575ebe77cb6d14fc7f32749631a6e44edbef6b796f89b020e99ba20d425"
 dependencies = [
  "axum-core 0.5.5",
  "bytes",
  "futures-util",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "itoa",
@@ -2097,7 +2099,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "mime",
@@ -2117,7 +2119,7 @@ checksum = "59446ce19cd142f8833f856eb31f3eb097812d1479ab224f54d72428ca21ea22"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "mime",
@@ -2170,7 +2172,7 @@ dependencies = [
  "object",
  "rustc-demangle",
  "serde",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2292,7 +2294,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2305,14 +2307,12 @@ dependencies = [
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
- "log",
- "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash 2.1.1",
  "shlex",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2413,7 +2413,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array 0.14.9",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -2422,7 +2422,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array 0.14.9",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -2473,9 +2473,9 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad8646f98db542e39fc66e68a20b2144f6a732636df7c2354e74645faaa433ce"
+checksum = "d1da5ab77c1437701eeff7c88d968729e7766172279eab0676857b3d63af7a6f"
 dependencies = [
  "borsh-derive",
  "cfg_aliases",
@@ -2483,15 +2483,15 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd1d3c0c2f5833f22386f252fe8ed005c7f59fdcddeef025c01b4c3b9fd9ac3"
+checksum = "0686c856aa6aac0c4498f936d7d6a02df690f614c03e4d906d1018062b5c5e2c"
 dependencies = [
  "once_cell",
  "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2571,7 +2571,7 @@ checksum = "89385e82b5d1821d2219e0b095efa2cc1f246cbf99080f3be46a1a85c0d392d9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2597,7 +2597,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2608,9 +2608,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 dependencies = [
  "serde",
 ]
@@ -2781,22 +2781,22 @@ checksum = "3fce8dd7fcfcbf3a0a87d8f515194b49d6135acab73e18bd380d1d93bb1a15eb"
 dependencies = [
  "clap",
  "heck 0.4.1",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "log",
  "proc-macro2",
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.109",
+ "syn 2.0.111",
  "tempfile",
  "toml 0.8.23",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.44"
+version = "1.2.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37521ac7aabe3d13122dc382493e20c9416f299d2ccd5b3a5340a2570cdeb0f3"
+checksum = "cd405d82c84ff7f35739f175f67d8b9fb7687a0e84ccdc78bd3568839827cf07"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -2829,7 +2829,7 @@ dependencies = [
  "base64 0.22.1",
  "celestia-proto",
  "celestia-types",
- "http 1.3.1",
+ "http 1.4.0",
  "jsonrpsee 0.26.0",
  "serde",
  "serde_repr",
@@ -3230,7 +3230,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -3269,9 +3269,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.51"
+version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c26d721170e0295f191a69bd9a1f93efcdb0aff38684b61ab5750468972e5f5"
+checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -3279,9 +3279,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.51"
+version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75835f0c7bf681bfd05abe44e965760fea999a5286c6eb2d59883634fd02011a"
+checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
 dependencies = [
  "anstream",
  "anstyle",
@@ -3298,7 +3298,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3334,9 +3334,9 @@ dependencies = [
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.31"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef8a506ec4b81c460798f572caead636d57d3d7e940f998160f52bd254bf2d23"
+checksum = "302266479cb963552d11bd042013a58ef1adc56768016c8b82b4199488f2d4ad"
 dependencies = [
  "compression-core",
  "flate2",
@@ -3345,9 +3345,9 @@ dependencies = [
 
 [[package]]
 name = "compression-core"
-version = "0.4.29"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e47641d3deaf41fb1538ac1f54735925e275eaf3bf4d55c81b137fba797e5cbb"
+checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
 name = "concurrent-queue"
@@ -3482,9 +3482,9 @@ dependencies = [
 
 [[package]]
 name = "crc"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
 dependencies = [
  "crc-catalog",
 ]
@@ -3565,7 +3565,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
 dependencies = [
- "generic-array 0.14.9",
+ "generic-array 0.14.7",
  "rand_core 0.6.4",
  "subtle",
  "zeroize",
@@ -3577,7 +3577,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
- "generic-array 0.14.9",
+ "generic-array 0.14.7",
  "rand_core 0.6.4",
  "subtle",
  "zeroize",
@@ -3585,11 +3585,11 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
- "generic-array 0.14.9",
+ "generic-array 0.14.7",
  "rand_core 0.6.4",
  "typenum",
 ]
@@ -3659,7 +3659,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3706,7 +3706,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3721,7 +3721,7 @@ dependencies = [
  "quote",
  "serde",
  "strsim",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3732,7 +3732,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3743,7 +3743,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3861,7 +3861,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3939,7 +3939,7 @@ checksum = "ef941ded77d15ca19b40374869ac6000af1c9f2a4c0f3d4c70926287e6364a8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3968,7 +3968,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3980,7 +3980,7 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
  "unicode-xid",
 ]
 
@@ -3990,7 +3990,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array 0.14.9",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -4100,7 +4100,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -4232,7 +4232,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -4274,7 +4274,7 @@ dependencies = [
  "der 0.6.1",
  "digest 0.10.7",
  "ff 0.12.1",
- "generic-array 0.14.9",
+ "generic-array 0.14.7",
  "group 0.12.1",
  "pkcs8 0.9.0",
  "rand_core 0.6.4",
@@ -4293,7 +4293,7 @@ dependencies = [
  "crypto-bigint 0.5.5",
  "digest 0.10.7",
  "ff 0.13.1",
- "generic-array 0.14.9",
+ "generic-array 0.14.7",
  "group 0.13.0",
  "hkdf",
  "pem-rfc7468",
@@ -4379,7 +4379,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -4400,7 +4400,7 @@ checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -4420,7 +4420,7 @@ checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -4432,7 +4432,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -4546,7 +4546,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -4678,9 +4678,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
+checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
 
 [[package]]
 name = "fixed-hash"
@@ -4881,7 +4881,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -4953,7 +4953,7 @@ dependencies = [
  "bytes",
  "chrono",
  "futures",
- "hyper 1.7.0",
+ "hyper 1.8.1",
  "jsonwebtoken",
  "once_cell",
  "prost 0.13.5",
@@ -4979,9 +4979,9 @@ checksum = "304de19db7028420975a296ab0fcbbc8e69438c4ed254a1e41e2a7f37d5f0e0a"
 
 [[package]]
 name = "generic-array"
-version = "0.14.9"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -5092,7 +5092,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -5110,8 +5110,8 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.3.1",
- "indexmap 2.12.0",
+ "http 1.4.0",
+ "indexmap 2.12.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -5299,14 +5299,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -5353,9 +5354,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hex-conservative"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
+checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
 dependencies = [
  "arrayvec",
 ]
@@ -5604,12 +5605,11 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
@@ -5631,7 +5631,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.3.1",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -5642,7 +5642,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -5685,16 +5685,16 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
 dependencies = [
  "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
  "h2 0.4.12",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
  "httpdate",
@@ -5728,8 +5728,8 @@ version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http 1.3.1",
- "hyper 1.7.0",
+ "http 1.4.0",
+ "hyper 1.8.1",
  "hyper-util",
  "log",
  "rustls 0.23.35",
@@ -5759,7 +5759,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.7.0",
+ "hyper 1.8.1",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -5787,7 +5787,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.7.0",
+ "hyper 1.8.1",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -5797,18 +5797,18 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
+checksum = "52e9a2a24dc5c6821e71a7030e1e14b7b632acac55c40e9d2e082c621261bb56"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
- "hyper 1.7.0",
+ "hyper 1.8.1",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -5996,9 +5996,9 @@ dependencies = [
  "attohttpc",
  "bytes",
  "futures",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body-util",
- "hyper 1.7.0",
+ "hyper 1.8.1",
  "hyper-util",
  "log",
  "rand 0.9.2",
@@ -6024,7 +6024,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -6046,12 +6046,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
+checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.0",
+ "hashbrown 0.16.1",
  "serde",
  "serde_core",
 ]
@@ -6095,7 +6095,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "generic-array 0.14.9",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -6231,7 +6231,7 @@ checksum = "980af8b43c3ad5d8d349ace167ec8170839f753a42d233ba19e08afe1850fa69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -6312,7 +6312,7 @@ checksum = "cf36eb27f8e13fa93dcb50ccb44c417e25b818cfa1a481b5470cd07b19c60b98"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
- "http 1.3.1",
+ "http 1.4.0",
  "jsonrpsee-core 0.26.0",
  "pin-project 1.1.10",
  "rustls 0.23.35",
@@ -6336,7 +6336,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "jsonrpsee-types 0.25.1",
@@ -6362,7 +6362,7 @@ dependencies = [
  "bytes",
  "futures-timer",
  "futures-util",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "jsonrpsee-types 0.26.0",
@@ -6387,7 +6387,7 @@ checksum = "790bedefcec85321e007ff3af84b4e417540d5c87b3c9779b9e247d1bcc3dab8"
 dependencies = [
  "base64 0.22.1",
  "http-body 1.0.1",
- "hyper 1.7.0",
+ "hyper 1.8.1",
  "hyper-rustls 0.27.7",
  "hyper-util",
  "jsonrpsee-core 0.26.0",
@@ -6412,7 +6412,7 @@ dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -6425,7 +6425,7 @@ dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -6435,10 +6435,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38b0bcf407ac68d241f90e2d46041e6a06988f97fe1721fb80b91c42584fae6"
 dependencies = [
  "futures-util",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.7.0",
+ "hyper 1.8.1",
  "hyper-util",
  "jsonrpsee-core 0.25.1",
  "jsonrpsee-types 0.25.1",
@@ -6461,7 +6461,7 @@ version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66df7256371c45621b3b7d2fb23aea923d577616b9c0e9c0b950a6ea5c2be0ca"
 dependencies = [
- "http 1.3.1",
+ "http 1.4.0",
  "serde",
  "serde_json",
  "thiserror 2.0.17",
@@ -6473,7 +6473,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc88ff4688e43cc3fa9883a8a95c6fa27aa2e76c96e610b737b6554d650d7fd5"
 dependencies = [
- "http 1.3.1",
+ "http 1.4.0",
  "serde",
  "serde_json",
  "thiserror 2.0.17",
@@ -6485,7 +6485,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b6fceceeb05301cc4c065ab3bd2fa990d41ff4eb44e4ca1b30fa99c057c3e79"
 dependencies = [
- "http 1.3.1",
+ "http 1.4.0",
  "jsonrpsee-client-transport",
  "jsonrpsee-core 0.26.0",
  "jsonrpsee-types 0.26.0",
@@ -7201,7 +7201,7 @@ dependencies = [
  "kona-std-fpvm 0.2.0 (git+https://github.com/op-rs/kona?tag=kona-client%2Fv1.1.7)",
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -7213,7 +7213,7 @@ dependencies = [
  "kona-std-fpvm 0.2.0 (git+https://github.com/celo-org/kona?rev=b0ea596)",
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -7297,7 +7297,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -7615,7 +7615,7 @@ checksum = "dd297cf53f0cb3dee4d2620bb319ae47ef27c702684309f682bdb7e55a18ae9c"
 dependencies = [
  "heck 0.5.0",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -7730,9 +7730,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.22"
+version = "1.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
+checksum = "15d118bbf3771060e7311cc7bb0545b01d08a8b4a7de949198dec1fa0ca1c0f7"
 dependencies = [
  "cc",
  "pkg-config",
@@ -7806,7 +7806,7 @@ dependencies = [
  "quote",
  "regex-syntax",
  "rustc_version 0.4.1",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -7842,7 +7842,7 @@ version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96051b46fc183dc9cd4a223960ef37b9af631b55191852a8274bfef064cda20f"
 dependencies = [
- "hashbrown 0.16.0",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -7877,7 +7877,7 @@ checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -7952,10 +7952,10 @@ checksum = "dd7399781913e5393588a8d8c6a2867bf85fb38eaf2502fdce465aad2dc6f034"
 dependencies = [
  "base64 0.22.1",
  "http-body-util",
- "hyper 1.7.0",
+ "hyper 1.8.1",
  "hyper-rustls 0.27.7",
  "hyper-util",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "ipnet",
  "metrics",
  "metrics-util 0.19.1",
@@ -7973,9 +7973,9 @@ checksum = "2b166dea96003ee2531cf14833efedced545751d800f03535801d833313f8c15"
 dependencies = [
  "base64 0.22.1",
  "http-body-util",
- "hyper 1.7.0",
+ "hyper 1.8.1",
  "hyper-util",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "ipnet",
  "metrics",
  "metrics-util 0.20.0",
@@ -8052,7 +8052,7 @@ checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -8278,7 +8278,7 @@ checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -8487,9 +8487,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint-dig"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82c79c15c05d4bf82b6f5ef163104cc81a760d8e874d38ac50ab67c8877b647b"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
 dependencies = [
  "lazy_static",
  "libm",
@@ -8632,7 +8632,7 @@ dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -8706,9 +8706,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "op-alloy-consensus"
-version = "0.22.0"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e42e9de945efe3c2fbd207e69720c9c1af2b8caa6872aee0e216450c25a3ca70"
+checksum = "726da827358a547be9f1e37c2a756b9e3729cb0350f43408164794b370cad8ae"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8725,9 +8725,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-network"
-version = "0.22.0"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9da49a2812a0189dd05e81e4418c3ae13fd607a92654107f02ebad8e91ed9e"
+checksum = "f63f27e65be273ec8fcb0b6af0fd850b550979465ab93423705ceb3dfddbd2ab"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -8741,9 +8741,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-provider"
-version = "0.22.0"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12ef7a7c6bfa366b29c44af9abe6e176c32ce54ed700ec1edd7526c469dcd28c"
+checksum = "a71456699aa256dc20119736422ad9a44da8b9585036117afb936778122093b9"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -8756,9 +8756,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-jsonrpsee"
-version = "0.22.0"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ceb771ab9323647093ea2e58dc7f25289a1b95cbef2faa2620f6ca2dee4d9"
+checksum = "8ef9114426b16172254555aad34a8ea96c01895e40da92f5d12ea680a1baeaa7"
 dependencies = [
  "alloy-primitives",
  "jsonrpsee 0.26.0",
@@ -8766,9 +8766,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-types"
-version = "0.22.0"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cd1eb7bddd2232856ba9d259320a094f9edf2b9061acfe5966e7960208393e6"
+checksum = "562dd4462562c41f9fdc4d860858c40e14a25df7f983ae82047f15f08fce4d19"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8785,9 +8785,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-types-engine"
-version = "0.22.0"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5429622150d18d8e6847a701135082622413e2451b64d03f979415d764566bef"
+checksum = "d8f24b8cb66e4b33e6c9e508bf46b8ecafc92eadd0b93fedd306c0accb477657"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9145,7 +9145,15 @@ dependencies = [
 name = "op-succinct-prove"
 version = "3.3.3-b"
 dependencies = [
+ "alloy-contract",
+ "alloy-eips",
+ "alloy-network",
+ "alloy-node-bindings",
  "alloy-primitives",
+ "alloy-provider",
+ "alloy-signer-local",
+ "alloy-sol-types",
+ "alloy-transport-http",
  "anyhow",
  "bincode",
  "cargo_metadata",
@@ -9156,6 +9164,7 @@ dependencies = [
  "op-succinct-build-utils",
  "op-succinct-client-utils",
  "op-succinct-elfs",
+ "op-succinct-fp",
  "op-succinct-host-utils",
  "op-succinct-proof-utils",
  "op-succinct-scripts",
@@ -9188,9 +9197,13 @@ name = "op-succinct-scripts"
 version = "3.3.3-b"
 dependencies = [
  "alloy-eips",
+ "alloy-network",
+ "alloy-node-bindings",
  "alloy-primitives",
+ "alloy-provider",
  "alloy-signer-local",
  "alloy-sol-types",
+ "alloy-transport-http",
  "anyhow",
  "bincode",
  "cargo_metadata",
@@ -9212,6 +9225,7 @@ dependencies = [
  "serde_json",
  "sp1-sdk",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -9280,9 +9294,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.74"
+version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ad14dd45412269e1a30f52ad8f0664f0f4f4a89ee8fe28c3b3527021ebb654"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
 dependencies = [
  "bitflags 2.10.0",
  "cfg-if",
@@ -9301,7 +9315,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -9321,9 +9335,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.110"
+version = "0.9.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a9f0075ba3c21b09f8e8b2026584b1d18d49388648f2fbbf3c97ea8deced8e2"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
 dependencies = [
  "cc",
  "libc",
@@ -9340,7 +9354,7 @@ checksum = "1e32339a5dc40459130b3bd269e9892439f55b33e772d2a9d402a789baaf4e8a"
 dependencies = [
  "futures-core",
  "futures-sink",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "js-sys",
  "once_cell",
  "pin-project-lite",
@@ -9798,7 +9812,7 @@ dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -9827,7 +9841,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -9899,9 +9913,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.3"
+version = "2.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e7521a040efde50c3ab6bbadafbe15ab6dc042686926be59ac35d74607df4"
+checksum = "cbcfd20a6d4eeba40179f05735784ad32bdaef05ce8e8af05f180d45bb3e7e22"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -9914,7 +9928,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
 ]
 
 [[package]]
@@ -9958,7 +9972,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -10007,7 +10021,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -10142,7 +10156,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -10226,7 +10240,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -10279,7 +10293,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -10347,7 +10361,7 @@ dependencies = [
  "prost 0.13.5",
  "prost-types 0.13.5",
  "regex",
- "syn 2.0.109",
+ "syn 2.0.111",
  "tempfile",
 ]
 
@@ -10361,7 +10375,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -10374,7 +10388,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -10387,7 +10401,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -10464,7 +10478,7 @@ checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -10568,9 +10582,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.41"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
+checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
@@ -10837,7 +10851,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -10937,10 +10951,10 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2 0.4.12",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.7.0",
+ "hyper 1.8.1",
  "hyper-rustls 0.27.7",
  "hyper-tls 0.6.0",
  "hyper-util",
@@ -10982,7 +10996,7 @@ checksum = "562ceb5a604d3f7c885a792d42c199fd8af239d0a51b2fa6a78aafa092452b04"
 dependencies = [
  "anyhow",
  "async-trait",
- "http 1.3.1",
+ "http 1.4.0",
  "reqwest 0.12.24",
  "serde",
  "thiserror 1.0.69",
@@ -10991,9 +11005,9 @@ dependencies = [
 
 [[package]]
 name = "resolv-conf"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b3789b30bd25ba102de4beabd95d21ac45b69b1be7d14522bab988c526d6799"
+checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "reth-chainspec"
@@ -11040,7 +11054,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.1#3afe69a5738459a7cb5
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -11471,9 +11485,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "9.0.5"
+version = "9.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b6c15bb255481fcf29f5ef7c97f00ed4c28a6ab6c490d77b990d73603031569"
+checksum = "980d8d6bba78c5dd35b83abbb6585b0b902eb25ea4448ed7bfba6283b0337191"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -11648,7 +11662,7 @@ dependencies = [
  "bytecheck",
  "bytes",
  "hashbrown 0.15.5",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "munge",
  "ptr_meta",
  "rancor",
@@ -11666,7 +11680,7 @@ checksum = "bd83f5f173ff41e00337d97f6572e416d022ef8a19f371817259ae960324c482"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -11729,9 +11743,9 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78928ac1ed176a5ca1d17e578a1825f3d81ca54cf41053a592584b020cfd691b"
+checksum = "40a0376c50d0358279d9d643e4bf7b7be212f1f4ff1da9070a7b54d22ef75c88"
 dependencies = [
  "const-oid",
  "digest 0.10.7",
@@ -11915,8 +11929,8 @@ checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
 name = "rust-kzg-bn254-primitives"
-version = "0.1.3"
-source = "git+https://github.com/Layr-Labs/rust-kzg-bn254.git#c09fafd757c94f13ed1ccfa051f8e31d6910673d"
+version = "0.1.4"
+source = "git+https://github.com/Layr-Labs/rust-kzg-bn254.git#7699464d82a11e9fd23531f3d9c92f24d601ba97"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -11933,8 +11947,8 @@ dependencies = [
 
 [[package]]
 name = "rust-kzg-bn254-prover"
-version = "0.1.2"
-source = "git+https://github.com/Layr-Labs/rust-kzg-bn254.git#c09fafd757c94f13ed1ccfa051f8e31d6910673d"
+version = "0.1.3"
+source = "git+https://github.com/Layr-Labs/rust-kzg-bn254.git#7699464d82a11e9fd23531f3d9c92f24d601ba97"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -11950,8 +11964,8 @@ dependencies = [
 
 [[package]]
 name = "rust-kzg-bn254-verifier"
-version = "0.1.3"
-source = "git+https://github.com/Layr-Labs/rust-kzg-bn254.git#c09fafd757c94f13ed1ccfa051f8e31d6910673d"
+version = "0.1.4"
+source = "git+https://github.com/Layr-Labs/rust-kzg-bn254.git#7699464d82a11e9fd23531f3d9c92f24d601ba97"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -12242,7 +12256,7 @@ dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -12317,7 +12331,7 @@ checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
 dependencies = [
  "base16ct 0.1.1",
  "der 0.6.1",
- "generic-array 0.14.9",
+ "generic-array 0.14.7",
  "pkcs8 0.9.0",
  "subtle",
  "zeroize",
@@ -12331,7 +12345,7 @@ checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct 0.2.0",
  "der 0.7.10",
- "generic-array 0.14.9",
+ "generic-array 0.14.7",
  "pkcs8 0.10.2",
  "serdect",
  "subtle",
@@ -12518,7 +12532,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -12527,7 +12541,7 @@ version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "itoa",
  "memchr",
  "ryu",
@@ -12554,7 +12568,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -12580,15 +12594,15 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.15.1"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa66c845eee442168b2c8134fec70ac50dc20e760769c8ba0ad1319ca1959b04"
+checksum = "10574371d41b0d9b2cff89418eda27da52bcaff2cc8741db26382a77c29131f1"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "schemars 0.9.0",
  "schemars 1.1.0",
  "serde_core",
@@ -12599,14 +12613,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.15.1"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91a903660542fced4e99881aa481bdbaec1634568ee02e0b8bd57c64cb38955"
+checksum = "08a72d8216842fdd57820dc78d840bef99248e35fb2554ff923319e60f2d686b"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -12653,7 +12667,7 @@ checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -12726,9 +12740,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.6"
+version = "1.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
+checksum = "7664a098b8e616bdfcc2dc0e9ac44eb231eedf41db4e9fe95d8d32ec728dedad"
 dependencies = [
  "libc",
 ]
@@ -12872,7 +12886,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures",
- "http 1.3.1",
+ "http 1.4.0",
  "httparse",
  "log",
  "rand 0.8.5",
@@ -13076,9 +13090,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-curves"
-version = "5.2.2"
+version = "5.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e29cb79716167e58c0719d572e686880172f1816cd85e0acab74ea0ff3c795e"
+checksum = "a6a7ce14c504360349f3eda564a0c9de286c35e1dfbcc979921a3384db02ae82"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -13098,9 +13112,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-derive"
-version = "5.2.2"
+version = "5.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ac59616976c008e862f99d26fd0c1c037d464df33d9ca548be88f938f0b1bcf"
+checksum = "9e1144840e0b75e988f3b8d24ffd015bc5fd76599f7864bfd994f3eaf2eb261a"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -13120,9 +13134,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "5.2.2"
+version = "5.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0244dee3a7a0f88cf71c3edf518f4fc97794ae870a107cbe7c810ac3fbf879cb"
+checksum = "a7d2a6187e394c30097ea7a975a4832f172918690dc89a979f0fad67422d3a8b"
 dependencies = [
  "bincode",
  "blake3",
@@ -13285,9 +13299,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-derive"
-version = "5.2.2"
+version = "5.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632f557f5bbfc8bc21b2bc319d3a375b46ea4522c00b875f02d73e4c0709b023"
+checksum = "6a8ca2e82fea312a406f4ad4cba1a11812da4cea806607c56ec1670fd55b2ea6"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -13374,9 +13388,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-stark"
-version = "5.2.2"
+version = "5.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f0cdde80366245a374d29fecdde2881286002a6e3f51b84f54b86560ed026e5"
+checksum = "40477690a0bb6d7102322947407439a8f1d05aecd535f0081db05e9a31f808f2"
 dependencies = [
  "arrayref",
  "hashbrown 0.14.5",
@@ -13513,7 +13527,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.15.5",
  "hashlink 0.10.0",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "log",
  "memchr",
  "native-tls",
@@ -13540,7 +13554,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -13563,7 +13577,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 2.0.109",
+ "syn 2.0.111",
  "tokio",
  "url",
 ]
@@ -13589,7 +13603,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-util",
- "generic-array 0.14.9",
+ "generic-array 0.14.7",
  "hex",
  "hkdf",
  "hmac",
@@ -13756,7 +13770,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -13768,7 +13782,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -13780,7 +13794,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -13846,9 +13860,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.109"
+version = "2.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f17c7e013e88258aa9543dcbe81aca68a667a9ac37cd69c9fbc07858bfe0e2f"
+checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13864,7 +13878,7 @@ dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -13902,7 +13916,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -13983,7 +13997,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -14091,7 +14105,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -14102,7 +14116,7 @@ checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -14243,7 +14257,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -14364,7 +14378,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "serde",
  "serde_spanned",
  "toml_datetime 0.6.11",
@@ -14378,7 +14392,7 @@ version = "0.23.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6485ef6d0d9b5d0ec17244ff7eb05310113c3f316f2d14200d4de56b3cb98f8d"
 dependencies = [
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "toml_datetime 0.7.3",
  "toml_parser",
  "winnow",
@@ -14438,10 +14452,10 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "h2 0.4.12",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.7.0",
+ "hyper 1.8.1",
  "hyper-timeout 0.5.2",
  "hyper-util",
  "percent-encoding",
@@ -14466,14 +14480,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
 dependencies = [
  "async-trait",
- "axum 0.8.6",
+ "axum 0.8.7",
  "base64 0.22.1",
  "bytes",
  "h2 0.4.12",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.7.0",
+ "hyper 1.8.1",
  "hyper-timeout 0.5.2",
  "hyper-util",
  "percent-encoding",
@@ -14518,7 +14532,7 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "pin-project-lite",
  "slab",
  "sync_wrapper 1.0.2",
@@ -14531,14 +14545,14 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+checksum = "9cf146f99d442e8e68e585f5d798ccd3cad9a7835b917e09728880a862706456"
 dependencies = [
  "bitflags 2.10.0",
  "bytes",
  "futures-util",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
@@ -14585,32 +14599,32 @@ dependencies = [
 
 [[package]]
 name = "tracing-appender"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
 dependencies = [
  "crossbeam-channel",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "time",
  "tracing-subscriber 0.3.20",
 ]
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c"
 dependencies = [
  "once_cell",
  "valuable",
@@ -14712,7 +14726,7 @@ checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.3.1",
+ "http 1.4.0",
  "httparse",
  "log",
  "rand 0.9.2",
@@ -14732,9 +14746,9 @@ dependencies = [
  "async-trait",
  "axum 0.7.9",
  "futures",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body-util",
- "hyper 1.7.0",
+ "hyper 1.8.1",
  "prost 0.13.5",
  "reqwest 0.12.24",
  "serde",
@@ -15046,7 +15060,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
  "wasm-bindgen-shared",
 ]
 
@@ -15269,9 +15283,9 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link 0.2.1",
+ "windows-link",
  "windows-result 0.4.1",
- "windows-strings 0.5.1",
+ "windows-strings",
 ]
 
 [[package]]
@@ -15281,7 +15295,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
  "windows-core 0.62.2",
- "windows-link 0.2.1",
+ "windows-link",
  "windows-threading",
 ]
 
@@ -15293,7 +15307,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -15304,14 +15318,8 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
-
-[[package]]
-name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-link"
@@ -15326,18 +15334,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
  "windows-core 0.62.2",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-registry"
-version = "0.5.3"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
+ "windows-link",
+ "windows-result 0.4.1",
+ "windows-strings",
 ]
 
 [[package]]
@@ -15351,29 +15359,11 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -15382,7 +15372,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -15436,7 +15426,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -15491,7 +15481,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -15508,7 +15498,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -15693,9 +15683,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
@@ -15868,28 +15858,28 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
  "synstructure 0.13.2",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.27"
+version = "0.8.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+checksum = "4ea879c944afe8a2b25fef16bb4ba234f47c694565e97383b36f3a878219065c"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.27"
+version = "0.8.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+checksum = "cf955aa904d6040f70dc8e9384444cb1030aed272ba3cb09bbc4ab9e7c1f34f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -15909,7 +15899,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
  "synstructure 0.13.2",
 ]
 
@@ -15930,7 +15920,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -15963,7 +15953,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]

--- a/book/SUMMARY.md
+++ b/book/SUMMARY.md
@@ -36,6 +36,7 @@
   - [Resources](./fault_proofs/resources.md)
     - [Gas Costs](./fault_proofs/gas_costs.md)
     - [Testing Guide](./fault_proofs/testing.md)
+    - [Pre-Flight Validation](./fault_proofs/preflight.md)
     - [Best Practices](./fault_proofs/best_practices.md)
   - [Experimental Features](./fault_proofs/experimental/experimental.md)
     - [Celestia DA](./fault_proofs/experimental/celestia.md)

--- a/book/fault_proofs/preflight.md
+++ b/book/fault_proofs/preflight.md
@@ -1,0 +1,119 @@
+# Pre-Flight Validation
+
+**Proving will break if parameters are incorrect.** After deploying contracts, run this script to verify the contract configuration before the mainnet upgrade.
+
+## What Does Pre-Flight Validate?
+
+Catches configuration issues before production by testing the complete proof generation and submission pipeline end-to-end. The game creation and proof submission is simulated on a forked L1 network.
+
+## Prerequisites
+
+- Deployed `DisputeGameFactory` contract
+- L1/L2 RPC access
+- SP1 network prover access
+
+## Required Environment Variables
+
+Create a `.env.preflight` file in the **repository root** with the following variables.
+
+> **Note:** Using `.env.preflight` avoids conflicts with existing `.env` files from deployments or other operations. You can specify a different file with `--env-file` if needed.
+
+### Contract Configuration
+```bash
+# Address of the DisputeGameFactory contract on L1
+FACTORY_ADDRESS=
+
+# Game type identifier for OPSuccinctFaultDisputeGames
+# This must match the game type registered in the factory
+GAME_TYPE=42
+
+# Optional: block number where DisputeGameFactory.setImplementation was called.
+# Set when you want to bypass on-chain log discovery (e.g., restrictive RPC rate limits).
+# SET_IMPL_BLOCK=<L1_BLOCK_NUMBER>
+```
+
+### Signing Configuration
+```bash
+# L1 private key used to create and prove the dispute game on the forked Anvil chain
+# This must be a whitelisted address in the OPSuccinctFaultDisputeGame contract
+PRIVATE_KEY=0x...
+```
+
+### Network Configuration
+```bash
+# L1 RPC endpoint (used for Anvil fork during validation)
+L1_RPC=<YOUR_L1_RPC>
+
+# L1 beacon chain RPC endpoint (needed when validating blocks with blob/EIP-4844 data)
+L1_BEACON_RPC=<YOUR_L1_BEACON_RPC>
+
+# L2 RPC endpoint
+L2_RPC=<YOUR_L2_RPC>
+
+# L2 node RPC endpoint (often same as L2_RPC)
+L2_NODE_RPC=<YOUR_L2_NODE_RPC>
+```
+
+### Prover Configuration
+```bash
+# Range proof fulfillment strategy
+# Options: "reserved", "hosted", "auction"
+# - reserved: Use SP1 Network Reserved mode (requires reserved capacity)
+# - hosted: Use SP1 Network Hosted mode (managed by SP1)
+# - auction: Use SP1 Network Auction mode (open competitive bidding)
+RANGE_PROOF_STRATEGY=auction
+
+# Aggregation proof fulfillment strategy
+# Options: "reserved", "hosted", "auction"
+# Compatibility rules:
+# - If RANGE_PROOF_STRATEGY is "auction", this must also be "auction"
+# - If RANGE_PROOF_STRATEGY is "reserved" or "hosted", this can be either "reserved" or "hosted"
+AGG_PROOF_STRATEGY=auction
+
+# Optional: aggregation proof mode ("plonk" default or "groth16")
+# Note: Changing the proof mode requires the corresponding SP1 verifier contract
+# address to be set in your deployment.
+# AGG_PROOF_MODE=plonk
+
+# Set to 'true' to use AWS KMS for key management (requires KMS configuration).
+# Set to 'false' to use a local private key (requires NETWORK_PRIVATE_KEY below).
+# Optional; defaults to 'false' if omitted.
+# USE_KMS_REQUESTER=false
+
+# SP1 network prover private key (required when USE_KMS_REQUESTER=false)
+# When USE_KMS_REQUESTER=true, this should be an AWS KMS key ARN instead
+NETWORK_PRIVATE_KEY=0x...
+```
+
+## Running Pre-Flight Validation
+
+Run the preflight script from the **repository root**:
+
+```bash
+RUST_LOG=info cargo run --release --bin preflight
+```
+
+```admonish note
+For rollups using alternative DA layers, compile with the matching feature flag:
+`--features celestia` or `--features eigenda` (for example,
+`RUST_LOG=info cargo run --release --features eigenda --bin preflight`).
+```
+
+By default, this uses `.env.preflight`. To use a different environment file:
+
+```bash
+RUST_LOG=info cargo run --release --bin preflight -- --env-file .env.custom
+```
+
+The script will:
+1. Fetch the anchor L2 block number from the factory
+2. Generate a range proof for the game
+3. Generate an aggregation proof for the game
+4. Fork L1 at a finalized block using Anvil
+5. Create a game at 10 blocks after the anchor
+6. Prove the game with the aggregation proof
+7. Verify the game has been validated with the aggregation proof
+
+Generated proofs are saved to:
+- `data/{CHAIN_ID}/proofs/range/{L2_START_BLOCK}-{L2_END_BLOCK}.bin`
+- `data/{CHAIN_ID}/proofs/agg/agg.bin`

--- a/book/introduction.md
+++ b/book/introduction.md
@@ -13,7 +13,7 @@ It combines a few key technologies:
 - [SP1](https://docs.succinct.xyz/docs/sp1/introduction), Succinct's state-of-the-art Rust zkVM
 - [Succinct Prover Network](https://docs.succinct.xyz/docs/sp1/prover-network/intro), Succinct's low-latency, cost-effective proving API
 
-OP Succinct is the only production-ready proving solution for the OP Stack and trusted by teams like [Mantle](https://www.mantle.xyz/blog/announcements/op-succinct-mantle-network-testnet) and [Phala](https://phala.network/posts/phala-network-20-first-opsuccinct-layer-2-on-ethereum).
+OP Succinct is the only production-ready proving solution for the OP Stack and trusted by teams like [Mantle](https://www.mantle.xyz/blog/announcements/op-succinct-mantle-network-testnet) and [Phala](https://phala.com/).
 
 
 ## Proving Options

--- a/celo/PROVE_DRYRUN_README.md
+++ b/celo/PROVE_DRYRUN_README.md
@@ -1,0 +1,71 @@
+# Prove Dry-Run
+
+A utility that performs an end-to-end dry-run of OP Succinct Fault Dispute Game proof flow for a specific game index.
+
+- Fetches the target game and its parent from the `DisputeGameFactory`.
+- Generates a Range Proof and validates public values against on-chain state.
+- Generates an Aggregation Proof and validates verification key commitments.
+- Spins up a local Anvil fork of L1 and submits the proof to `prove` for a full preflight.
+
+This is intended for local validation without sending real transactions on L1.
+
+## Usage
+
+### Basic Command
+
+```bash
+cargo run --release --bin prove-dryrun --features eigenda -- \
+  --index <GAME_INDEX> [--env-file <PATH_TO_ENV>]
+```
+
+- `--index <GAME_INDEX>`: index of the game in the `DisputeGameFactory`.
+- `--env-file <PATH>`: Path to environment file. Default: `.env.prove_dryrun`.
+
+## Environment
+
+Use `.env.example.prove_dryrun` as a template. Relevant variables:
+
+- `L1_RPC`: L1 execution RPC URL
+- `L1_BEACON_RPC`: L1 consensus RPC URL
+- `L2_RPC`: L2 execution RPC URL
+- `L2_NODE_RPC`: L2 consensus RPC URL
+- `EIGENDA_PROXY_ADDRESS`: EigenDA proxy URL
+- `USE_KMS_REQUESTER`: If `false`, expects `NETWORK_PRIVATE_KEY` to be an AWS KMS key ARN
+- `NETWORK_PRIVATE_KEY`: Succinct Prover Network private key
+- `RANGE_PROOF_STRATEGY`: Range proof fulfillment strategy (default: `reserved`)
+- `AGG_PROOF_STRATEGY`: Aggregation proof fulfillment strategy (default: `reserved`)
+- `AGG_PROOF_MODE`: Aggregation proof mode: `plonk` (default) or `groth16`
+- `FACTORY_ADDRESS`: Address of the `DisputeGameFactory`
+- `GAME_TYPE`: Fault dispute game type (e.g., `42`)
+- `PROPOSER_ADDRESS`: Proposer address
+- `PRIVATE_KEY`: Transaction signer private key (funded on L1 fork or Anvil; used when calling `prove` on Anvil)
+
+## What It Does
+
+1. Fetches parent game and target game from the `DisputeGameFactory`.
+2. Builds Range Proof witness using the host, runs SP1 network proving, and saves the proof to:
+   - `data/<L2_CHAIN_ID>/proofs/range/<L2_START>-<L2_END>.bin`
+3. Validates public values and commitments against on-chain game state:
+   - L1 head hash
+   - L2 post-state root
+   - Rollup config hash
+   - Range verification key hash
+4. Builds Aggregation Proof (PLONK or Groth16, determined by `AGG_PROOF_MODE`), validates aggregation vkey commitment, and saves to:
+   - `data/<L2_CHAIN_ID>/proofs/agg/agg.bin`
+5. Starts a local Anvil node forked from `L1_RPC` at `l1_head + 1`, submits `prove(agg_proof)` to the game, mines a block, and asserts the final status is `UnchallengedAndValidProofProvided`.
+
+## Examples
+
+Run with default env file and a specific game index:
+
+```bash
+cargo run --release --bin prove-dryrun -- --index 100
+```
+
+Run with a custom env file:
+
+```bash
+cargo run --release --bin prove-dryrun -- \
+  --env-file .env.mainnet \
+  --index 2072
+```

--- a/fault-proof/src/contract.rs
+++ b/fault-proof/src/contract.rs
@@ -12,6 +12,9 @@ sol! {
         /// @notice Emitted when a new dispute game is created.
         event DisputeGameCreated(address indexed disputeProxy, GameType indexed gameType, Claim indexed rootClaim);
 
+        /// @notice Emitted when a new game implementation added to the factory
+        event ImplementationSet(address indexed impl, GameType indexed gameType);
+
         /// @notice `gameImpls` is a mapping that maps `GameType`s to their respective
         ///         `IDisputeGame` implementations.
         mapping(GameType => IDisputeGame) public gameImpls;

--- a/fault-proof/src/contract.rs
+++ b/fault-proof/src/contract.rs
@@ -68,6 +68,15 @@ sol! {
         /// @notice Getter for the parent hash of the L1 block when the dispute game was created.
         function l1Head() public pure returns (Hash l1Head_);
 
+         /// @notice Returns the rollup config hash.
+        function rollupConfigHash() public pure returns (Hash rollupConfigHash_);
+
+        /// @notice Returns the aggregation vkey.
+        function aggregationVkey() public pure returns (Hash aggregationVkey_);
+
+        /// @notice Returns the range vkey commitment.
+        function rangeVkeyCommitment() public pure returns (Hash rangeVkeyCommitment_);
+
         /// @notice Getter for the status of the game.
         function status() public view returns (GameStatus status_);
 

--- a/scripts/prove/Cargo.toml
+++ b/scripts/prove/Cargo.toml
@@ -33,9 +33,21 @@ op-succinct-client-utils.workspace = true
 op-succinct-proof-utils.workspace = true
 op-succinct-scripts = { path = "../utils" }
 op-succinct-elfs.workspace = true
+op-succinct-fp.workspace = true
 
 # alloy
+alloy-contract.workspace = true
+alloy-eips.workspace = true
+alloy-network.workspace = true
+alloy-node-bindings.workspace = true
 alloy-primitives.workspace = true
+alloy-signer-local.workspace = true
+alloy-sol-types.workspace = true
+alloy-provider = { workspace = true, features = ["reqwest"] }
+alloy-transport-http = { workspace = true, features = [
+    "reqwest",
+    "reqwest-native-tls",
+] }
 
 # sp1
 sp1-sdk.workspace = true

--- a/scripts/utils/Cargo.toml
+++ b/scripts/utils/Cargo.toml
@@ -47,6 +47,10 @@ path = "bin/parallel_cost_estimator.rs"
 name = "preflight"
 path = "bin/preflight.rs"
 
+[[bin]]
+name = "prove-dryrun"
+path = "bin/prove_dryrun.rs"
+
 [dependencies]
 
 # workspace

--- a/scripts/utils/Cargo.toml
+++ b/scripts/utils/Cargo.toml
@@ -43,9 +43,20 @@ path = "bin/gen_sp1_test_artifacts.rs"
 name = "parallel-cost-estimator"
 path = "bin/parallel_cost_estimator.rs"
 
+[[bin]]
+name = "preflight"
+path = "bin/preflight.rs"
+
 [dependencies]
 
 # workspace
+alloy-network.workspace = true
+alloy-node-bindings.workspace = true
+alloy-provider = { workspace = true, features = ["reqwest"] }
+alloy-transport-http = { workspace = true, features = [
+    "reqwest",
+    "reqwest-native-tls",
+] }
 alloy-primitives.workspace = true
 alloy-sol-types.workspace = true
 alloy-signer-local.workspace = true
@@ -63,6 +74,7 @@ futures.workspace = true
 rayon = "1.10.0"
 serde_json.workspace = true
 env_logger = "0.11"
+tracing.workspace = true
 
 # local
 op-succinct-host-utils.workspace = true

--- a/scripts/utils/bin/preflight.rs
+++ b/scripts/utils/bin/preflight.rs
@@ -1,0 +1,377 @@
+use std::{env, fs, path::PathBuf, str::FromStr, sync::Arc};
+
+use alloy_eips::{BlockId, BlockNumberOrTag};
+use alloy_network::EthereumWallet;
+use alloy_node_bindings::Anvil;
+use alloy_primitives::{Address, U256};
+use alloy_provider::{Provider, ProviderBuilder};
+use alloy_signer_local::PrivateKeySigner;
+use alloy_sol_types::SolValue;
+use alloy_transport_http::reqwest::Url;
+use anyhow::{anyhow, Context, Result};
+use clap::Parser;
+use fault_proof::{
+    contract::{DisputeGameFactory, OPSuccinctFaultDisputeGame, ProposalStatus},
+    FactoryTrait,
+};
+use op_succinct_client_utils::boot::BootInfoStruct;
+use op_succinct_elfs::AGGREGATION_ELF;
+use op_succinct_host_utils::{
+    fetcher::OPSuccinctDataFetcher,
+    get_agg_proof_stdin,
+    host::OPSuccinctHost,
+    network::{determine_network_mode, get_network_signer, parse_fulfillment_strategy},
+    witness_generation::WitnessGenerator,
+};
+use op_succinct_proof_utils::{get_range_elf_embedded, initialize_host};
+use sp1_sdk::{utils, Prover, ProverClient, SP1ProofMode};
+use tracing::info;
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// The environment file path.
+    #[arg(long, default_value = ".env.preflight")]
+    env_file: PathBuf,
+}
+
+/// Fetches the block number when the game implementation was set for the given game type.
+/// Queries the ImplementationSet event from the DisputeGameFactory contract.
+/// Uses chunked queries to avoid exceeding RPC provider's max block range limits.
+async fn get_implementation_set_block(
+    factory_address: Address,
+    provider: Arc<impl Provider + 'static>,
+    game_type: u32,
+) -> Result<u64> {
+    let factory = DisputeGameFactory::new(factory_address, provider.clone());
+
+    // Get the latest block number
+    let latest_block = provider.get_block_number().await?;
+
+    // Query in chunks to avoid exceeding max block range (default 100,000 blocks)
+    let chunk_size = env::var("CHUNK_SIZE")
+        .ok()
+        .map(|val| val.trim().parse::<u64>().context("CHUNK_SIZE must be a valid u64"))
+        .transpose()?
+        .unwrap_or(100_000);
+
+    if chunk_size == 0 {
+        return Err(anyhow!("CHUNK_SIZE must be greater than 0"));
+    }
+
+    info!("Using chunk size of {} blocks when searching for ImplementationSet event", chunk_size);
+
+    let mut end_block = latest_block;
+
+    info!(
+        "Searching for ImplementationSet event for game type {} (latest block: {})",
+        game_type, latest_block
+    );
+
+    loop {
+        // Calculate start block for this chunk, ensuring we don't go below 0
+        let start_block = end_block.saturating_sub(chunk_size);
+
+        // Query ImplementationSet events filtered by game type for this chunk
+        // Note: gameType is the second indexed parameter, so it's topic2
+        let filter = factory
+            .ImplementationSet_filter()
+            .topic2(U256::from(game_type))
+            .from_block(start_block)
+            .to_block(end_block);
+
+        let logs = filter.query().await?;
+
+        // If we found any events, return the most recent one
+        if !logs.is_empty() {
+            let (_event, log) = logs.last().ok_or_else(|| {
+                anyhow!("No ImplementationSet event found for game type {}", game_type)
+            })?;
+
+            let block_number = log
+                .block_number
+                .ok_or_else(|| anyhow!("Block number not found in ImplementationSet event"))?;
+
+            info!(
+                "Found ImplementationSet event for game type {} at block {}",
+                game_type, block_number
+            );
+            return Ok(block_number);
+        }
+
+        // If we've reached block 0 and haven't found anything, error out
+        if start_block == 0 {
+            return Err(anyhow!(
+                "No ImplementationSet event found for game type {} in entire chain history",
+                game_type
+            ));
+        }
+
+        // Move to the next chunk (going backwards in time)
+        end_block = start_block.saturating_sub(1);
+    }
+}
+
+/// Preflight check for the OP Succinct Fault Dispute Game.
+#[tokio::main]
+async fn main() -> Result<()> {
+    // 1. Set up the environment.
+    utils::setup_logger();
+
+    let args = Args::parse();
+
+    dotenv::from_path(&args.env_file)
+        .context(format!("Environment file not found: {}", args.env_file.display()))?;
+
+    let wallet = PrivateKeySigner::from_str(env::var("PRIVATE_KEY")?.as_str())
+        .context("failed to parse private key")?;
+
+    let use_kms_requester = env::var("USE_KMS_REQUESTER")
+        .unwrap_or_else(|_| "false".to_string())
+        .parse::<bool>()
+        .context("USE_KMS_REQUESTER must be true or false")?;
+
+    let data_fetcher = OPSuccinctDataFetcher::new_with_rollup_config().await?;
+
+    let factory = DisputeGameFactory::new(
+        env::var("FACTORY_ADDRESS")?.parse::<Address>().expect("FACTORY_ADDRESS must be set"),
+        data_fetcher.l1_provider.clone(),
+    );
+    info!("Factory at address: {}", factory.address());
+
+    let game_type = env::var("GAME_TYPE")?.parse::<u32>().expect("GAME_TYPE must be set");
+
+    let anchor_l2_block_number = factory.get_anchor_l2_block_number(game_type).await?;
+    info!("Anchor L2 block number: {}", anchor_l2_block_number);
+
+    let l2_start_block = anchor_l2_block_number.to::<u64>();
+    let l2_end_block = l2_start_block + 10;
+
+    // Use finalized L1 block's hash as the L1 head hash since the factory
+    // might have been deployed later than the safe L1 head of the L2 end block.
+    let l1_head = {
+        data_fetcher
+            .get_l1_head(l2_end_block, false)
+            .await
+            .context("failed to fetch L1 head (pre-check)")?;
+
+        let finalized_l1_header = data_fetcher
+            .get_l1_header(BlockId::finalized())
+            .await
+            .context("failed to fetch finalized L1 header")?;
+        info!("Finalized L1 block number: {}", finalized_l1_header.number);
+
+        // Fetch the block number when the implementation was set for this game type
+        // by querying the ImplementationSet event from the DisputeGameFactory contract.
+        let set_impl_block_number =
+            match env::var("SET_IMPL_BLOCK").ok().filter(|s| !s.trim().is_empty()) {
+                Some(val) => {
+                    let parsed = val
+                        .parse::<u64>()
+                        .context("SET_IMPL_BLOCK must be a positive integer block number")?;
+                    info!("Using SET_IMPL_BLOCK from env (skipping log search): {}", parsed);
+                    parsed
+                }
+                None => {
+                    info!("SET_IMPL_BLOCK not provided; searching for ImplementationSet event");
+                    get_implementation_set_block(
+                        *factory.address(),
+                        data_fetcher.l1_provider.clone(),
+                        game_type,
+                    )
+                    .await?
+                }
+            };
+
+        let l1_header_after_set_impl = data_fetcher
+            .get_l1_header(BlockId::Number(BlockNumberOrTag::Number(set_impl_block_number + 1)))
+            .await?;
+
+        if l1_header_after_set_impl.number < finalized_l1_header.number {
+            l1_header_after_set_impl
+        } else {
+            panic!("Set implementation L1 block number is greater than finalized L1 block number");
+        }
+    };
+
+    let l1_head_hash = l1_head.hash_slow();
+    info!("L1 head number: {:?}", l1_head.number);
+    info!("L1 head hash: {:?}", l1_head_hash);
+
+    // 2. Generate the range proof.
+    let host = initialize_host(Arc::new(data_fetcher.clone()));
+    let host_args = host.fetch(l2_start_block, l2_end_block, Some(l1_head_hash), false).await?;
+
+    info!("Generating range proof witness data...");
+    let witness_data = host.run(&host_args).await?;
+    info!("Range proof witness data generated successfully");
+
+    info!("Getting range proof stdin...");
+    let range_proof_stdin = host.witness_generator().get_sp1_stdin(witness_data)?;
+    info!("Range proof stdin generated successfully");
+
+    // Initialize the network prover.
+    let network_signer = get_network_signer(use_kms_requester).await?;
+
+    let range_proof_strategy = parse_fulfillment_strategy(env::var("RANGE_PROOF_STRATEGY")?);
+    info!("Range proof strategy: {:?}", range_proof_strategy);
+
+    let agg_proof_strategy = parse_fulfillment_strategy(env::var("AGG_PROOF_STRATEGY")?);
+    info!("Aggregation proof strategy: {:?}", agg_proof_strategy);
+
+    let network_mode = determine_network_mode(range_proof_strategy, agg_proof_strategy)
+        .context("failed to determine network mode from range and agg fulfillment strategies")?;
+    let network_prover =
+        ProverClient::builder().network_for(network_mode).signer(network_signer.clone()).build();
+    info!("Initialized network prover successfully");
+
+    let (range_pk, _range_vk) = network_prover.setup(get_range_elf_embedded());
+    let mut range_proof = network_prover
+        .prove(&range_pk, &range_proof_stdin)
+        .compressed()
+        .strategy(range_proof_strategy)
+        .run()
+        .unwrap();
+
+    // Save the proof to the proof directory corresponding to the chain ID.
+    let range_proof_dir =
+        format!("data/{}/proofs/range", data_fetcher.get_l2_chain_id().await.unwrap());
+    if !std::path::Path::new(&range_proof_dir).exists() {
+        fs::create_dir_all(&range_proof_dir).unwrap();
+    }
+    range_proof
+        .save(format!("{range_proof_dir}/{l2_start_block}-{l2_end_block}.bin"))
+        .expect("saving proof failed");
+    info!("Range proof saved to {range_proof_dir}/{l2_start_block}-{l2_end_block}.bin");
+
+    // 3. Generate the aggregation proof.
+    let boot_info: BootInfoStruct = range_proof.public_values.read();
+    assert_eq!(boot_info.l1Head, l1_head_hash, "L1 head hash mismatch");
+
+    // Initialize the network prover.
+    let network_prover =
+        ProverClient::builder().network_for(network_mode).signer(network_signer).build();
+    info!("Initialized network prover successfully");
+
+    let (_, range_vk) = network_prover.setup(get_range_elf_embedded());
+
+    let agg_proof_stdin = get_agg_proof_stdin(
+        vec![range_proof.proof],
+        vec![boot_info.clone()],
+        vec![l1_head.clone()],
+        &range_vk,
+        boot_info.l1Head,
+        wallet.address(),
+    )
+    .context("failed to get agg proof stdin")?;
+
+    let agg_proof_mode_env = env::var("AGG_PROOF_MODE")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| "plonk".to_string());
+    let agg_proof_mode = match agg_proof_mode_env.to_lowercase().as_str() {
+        "groth16" => SP1ProofMode::Groth16,
+        "plonk" => SP1ProofMode::Plonk,
+        other => {
+            return Err(anyhow!(
+                "Invalid AGG_PROOF_MODE '{}'. Expected one of: plonk, groth16",
+                other
+            ))
+        }
+    };
+    info!("Aggregation proof mode: {:?}", agg_proof_mode);
+
+    let (agg_pk, _) = network_prover.setup(AGGREGATION_ELF);
+    let agg_proof = network_prover
+        .prove(&agg_pk, &agg_proof_stdin)
+        .mode(agg_proof_mode)
+        .strategy(agg_proof_strategy)
+        .run()
+        .unwrap();
+
+    let agg_proof_dir =
+        format!("data/{}/proofs/agg", data_fetcher.get_l2_chain_id().await.unwrap());
+    if !std::path::Path::new(&agg_proof_dir).exists() {
+        fs::create_dir_all(&agg_proof_dir).unwrap();
+    }
+
+    agg_proof.save(format!("{agg_proof_dir}/agg.bin")).expect("saving proof failed");
+    info!("Agg proof saved to {agg_proof_dir}/agg.bin");
+
+    // 4. Spin up anvil.
+    let l1_head_number =
+        data_fetcher.l1_provider.get_block_by_hash(boot_info.l1Head).await?.unwrap().header.number;
+
+    let anvil = Anvil::new()
+        .fork(env::var("L1_RPC").expect("L1_RPC must be set"))
+        .fork_block_number(l1_head_number)
+        .args(["--no-mining"]);
+    let anvil_instance = anvil.spawn();
+    let endpoint = anvil_instance.endpoint();
+    info!("Anvil chain started forked from L1 block number: {} at: {}", l1_head_number, endpoint);
+
+    // 5. Run the preflight check.
+    let provider_with_signer = ProviderBuilder::new()
+        .wallet(EthereumWallet::from(wallet))
+        .connect_http(Url::parse(&endpoint)?);
+
+    let factory = DisputeGameFactory::new(*factory.address(), provider_with_signer.clone());
+
+    let game_type = env::var("GAME_TYPE")?.parse::<u32>().expect("GAME_TYPE must be set");
+    let init_bond = factory.initBonds(game_type).call().await?;
+    let parent_index = u32::MAX;
+    let extra_data = (U256::from(l2_end_block), parent_index).abi_encode_packed();
+
+    let tx = factory
+        .create(game_type, boot_info.l2PostRoot, extra_data.into())
+        .value(init_bond)
+        .send()
+        .await?;
+
+    let client = provider_with_signer.client();
+    let _: String = client.request("evm_mine", Vec::<serde_json::Value>::new()).await?;
+
+    let block = provider_with_signer.get_block_by_number(BlockNumberOrTag::Latest).await?;
+    info!("Mined block: {}", block.unwrap().header.number);
+
+    let receipt = tx.get_receipt().await?;
+    info!("Transaction receipt: {:?}", receipt);
+
+    let new_game_count = factory.gameCount().call().await?;
+    let game_index = new_game_count - U256::from(1);
+    let game_info = factory.gameAtIndex(game_index).call().await?;
+    let game_address = game_info.proxy;
+    info!("Game address: {}", game_address);
+
+    let game = OPSuccinctFaultDisputeGame::new(game_address, provider_with_signer.clone());
+
+    // Debug: Check what the game expects
+    let game_l1_head = game.l1Head().call().await?;
+    info!("Game's L1 head: {:?}", game_l1_head);
+    info!("Proof's L1 head (boot_info.l1Head): {:?}", boot_info.l1Head);
+
+    if game_l1_head != boot_info.l1Head {
+        return Err(anyhow!(
+            "L1 head mismatch! Game expects {:?} but proof contains {:?}",
+            game_l1_head,
+            boot_info.l1Head
+        ));
+    }
+
+    let tx = game.prove(agg_proof.bytes().into()).send().await?;
+
+    let _: String = client.request("evm_mine", Vec::<serde_json::Value>::new()).await?;
+
+    let block = provider_with_signer.get_block_by_number(BlockNumberOrTag::Latest).await?;
+    info!("Mined block: {}", block.unwrap().header.number);
+
+    let receipt = tx.get_receipt().await?;
+    info!("Transaction receipt: {:?}", receipt);
+
+    let claim_data = game.claimData().call().await?;
+    assert_eq!(claim_data.status, ProposalStatus::UnchallengedAndValidProofProvided);
+
+    info!("Successfully completed preflight check");
+
+    Ok(())
+}

--- a/scripts/utils/bin/prove_dryrun.rs
+++ b/scripts/utils/bin/prove_dryrun.rs
@@ -1,0 +1,312 @@
+use std::{env, fs, path::PathBuf, str::FromStr, sync::Arc};
+
+use alloy_eips::BlockNumberOrTag;
+use alloy_network::EthereumWallet;
+use alloy_node_bindings::Anvil;
+use alloy_primitives::{Address, B256, U256};
+use alloy_provider::{Provider, ProviderBuilder};
+use alloy_signer_local::PrivateKeySigner;
+use alloy_transport_http::reqwest::Url;
+use anyhow::{anyhow, Context, Result};
+use clap::Parser;
+use fault_proof::contract::{DisputeGameFactory, OPSuccinctFaultDisputeGame, ProposalStatus};
+use op_succinct_client_utils::{boot::BootInfoStruct, types::u32_to_u8};
+use op_succinct_elfs::AGGREGATION_ELF;
+use op_succinct_host_utils::{
+    fetcher::OPSuccinctDataFetcher,
+    get_agg_proof_stdin,
+    host::OPSuccinctHost,
+    network::{determine_network_mode, get_network_signer, parse_fulfillment_strategy},
+    witness_generation::WitnessGenerator,
+};
+use op_succinct_proof_utils::{get_range_elf_embedded, initialize_host};
+use sp1_sdk::{
+    network::FulfillmentStrategy, utils, HashableKey, Prover, ProverClient, SP1ProofMode,
+};
+use tracing::info;
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// The environment file path.
+    #[arg(long, default_value = ".env.prove_dryrun")]
+    env_file: PathBuf,
+
+    /// Index of the game to prove.
+    #[arg(long, value_parser = clap::value_parser!(u64).range(1..))]
+    index: u64,
+}
+
+#[derive(Debug, Clone)]
+struct Config {
+    /// The L1 RPC URL.
+    pub l1_rpc: Url,
+
+    /// The address of the factory contract.
+    pub factory_address: Address,
+
+    /// Proof fulfillment strategy for range proofs.
+    pub range_proof_strategy: FulfillmentStrategy,
+
+    /// Proof fulfillment strategy for aggregation proofs.
+    pub agg_proof_strategy: FulfillmentStrategy,
+
+    // Aggregation proof mode (plonk/groth16)
+    pub agg_proof_mode: String,
+
+    /// Proposer private key
+    pub private_key: String,
+
+    /// Whether to expect NETWORK_PRIVATE_KEY to be an AWS KMS key ARN instead of a
+    /// plaintext private key.
+    pub use_kms_requester: bool,
+}
+
+impl Config {
+    pub fn from_env() -> Result<Self> {
+        Ok(Self {
+            l1_rpc: env::var("L1_RPC")
+                .context("L1_RPC must be set")?
+                .parse()
+                .expect("failed to parse L1_RPC"),
+            factory_address: env::var("FACTORY_ADDRESS")
+                .context("FACTORY_ADDRESS must be set")?
+                .parse()
+                .expect("failed to parse FACTORY_ADDRESS"),
+            range_proof_strategy: parse_fulfillment_strategy(
+                env::var("RANGE_PROOF_STRATEGY").unwrap_or("reserved".to_string()),
+            ),
+            agg_proof_strategy: parse_fulfillment_strategy(
+                env::var("AGG_PROOF_STRATEGY").unwrap_or("reserved".to_string()),
+            ),
+            agg_proof_mode: env::var("AGG_PROOF_MODE")
+                .ok()
+                .filter(|s| !s.trim().is_empty())
+                .unwrap_or_else(|| "plonk".to_string()),
+            private_key: env::var("PRIVATE_KEY")
+                .context("PRIVATE_KEY must be set")?
+                .parse()
+                .expect("failed to parse PRIVATE_KEY"),
+            use_kms_requester: env::var("USE_KMS_REQUESTER")
+                .unwrap_or("false".to_string())
+                .parse()?,
+        })
+    }
+}
+
+/// Preflight check for the OP Succinct Fault Dispute Game.
+#[tokio::main]
+async fn main() -> Result<()> {
+    // 1. Set up the environment.
+    utils::setup_logger();
+
+    let args = Args::parse();
+
+    dotenv::from_path(&args.env_file)
+        .context(format!("Environment file not found: {}", args.env_file.display()))?;
+
+    let config = Config::from_env()?;
+
+    let wallet =
+        PrivateKeySigner::from_str(&config.private_key).context("failed to parse private key")?;
+
+    let network_signer = get_network_signer(config.use_kms_requester).await?;
+    let network_mode =
+        determine_network_mode(config.range_proof_strategy, config.agg_proof_strategy).context(
+            "failed to determine network mode from range and agg fulfillment strategies",
+        )?;
+
+    let data_fetcher = OPSuccinctDataFetcher::new_with_rollup_config().await?;
+
+    let factory = DisputeGameFactory::new(config.factory_address, data_fetcher.l1_provider.clone());
+
+    let parent_game = OPSuccinctFaultDisputeGame::new(
+        factory
+            .gameAtIndex(U256::from(args.index - 1))
+            .call()
+            .await
+            .with_context(|| {
+                format!("failed to fetch the parent game at index {}", args.index - 1)
+            })?
+            .proxy,
+        data_fetcher.l1_provider.clone(),
+    );
+    let game = OPSuccinctFaultDisputeGame::new(
+        factory
+            .gameAtIndex(U256::from(args.index))
+            .call()
+            .await
+            .with_context(|| format!("failed to fetch the game at index {}", args.index))?
+            .proxy,
+        data_fetcher.l1_provider.clone(),
+    );
+
+    info!("Proving for Game #{} (address: {})", args.index, game.address());
+
+    let l1_head_hash: [u8; 32] = game.l1Head().call().await?.0;
+    let l2_start_block = parent_game.l2BlockNumber().call().await?.to::<u64>();
+    let l2_end_block = game.l2BlockNumber().call().await?.to::<u64>();
+
+    let l1_head = data_fetcher
+        .l1_provider
+        .get_block_by_hash(l1_head_hash.into())
+        .await?
+        .expect("failed to fetch L1 head block")
+        .header;
+
+    info!(
+        l2_start_block,
+        l2_end_block,
+        l1_head_number = l1_head.number,
+        l1_head_hash = %l1_head.hash,
+        "Proving L2 block range against L1 head"
+    );
+
+    // 2. Generate the range proof.
+    let host = initialize_host(Arc::new(data_fetcher.clone()));
+    let host_args =
+        host.fetch(l2_start_block, l2_end_block, Some(l1_head_hash.into()), false).await?;
+
+    info!("Generating range proof witness data...");
+    let witness_data = host.run(&host_args).await?;
+    info!("Range proof witness data generated successfully");
+
+    info!("Getting range proof stdin...");
+    let range_proof_stdin = host.witness_generator().get_sp1_stdin(witness_data)?;
+    info!("Range proof stdin generated successfully");
+
+    // Initialize the network prover.
+    let network_prover =
+        ProverClient::builder().network_for(network_mode).signer(network_signer.clone()).build();
+    info!("Initialized network prover successfully");
+
+    let (range_pk, range_vk) = network_prover.setup(get_range_elf_embedded());
+    let mut range_proof = network_prover
+        .prove(&range_pk, &range_proof_stdin)
+        .compressed()
+        .strategy(config.range_proof_strategy)
+        .run()
+        .unwrap();
+
+    // Save the proof to the proof directory corresponding to the chain ID.
+    let range_proof_dir =
+        format!("data/{}/proofs/range", data_fetcher.get_l2_chain_id().await.unwrap());
+    if !std::path::Path::new(&range_proof_dir).exists() {
+        fs::create_dir_all(&range_proof_dir).unwrap();
+    }
+    range_proof
+        .save(format!("{range_proof_dir}/{l2_start_block}-{l2_end_block}.bin"))
+        .expect("saving proof failed");
+    info!("Range proof saved to {range_proof_dir}/{l2_start_block}-{l2_end_block}.bin");
+
+    // Validation
+    let boot_info: BootInfoStruct = range_proof.public_values.read();
+
+    info!("BootInfo L1 head: {:?}", boot_info.l1Head);
+    info!("Game L1 head:     {:?}", l1_head.hash);
+    assert_eq!(boot_info.l1Head, l1_head.hash, "L1 head hash mismatch");
+
+    let game_root_claim = game.rootClaim().call().await?;
+    info!("Boot Info L2PostRoot: {:?}", boot_info.l2PostRoot);
+    info!("Game Root Claim:      {:?}", game_root_claim);
+    assert_eq!(boot_info.l2PostRoot, game_root_claim, "Root claim mismatch");
+
+    let game_rollup_config_hash = game.rollupConfigHash().call().await?;
+    info!("Boot Info Rollup Config Hash: {:?}", boot_info.rollupConfigHash);
+    info!("Game Rollup Config Hash:      {:?}", game_rollup_config_hash);
+    assert_eq!(boot_info.rollupConfigHash, game_rollup_config_hash, "Rollup config hash mismatch");
+
+    let range_vk_hash = B256::from(u32_to_u8(range_vk.vk.hash_u32()));
+    let game_range_v_key_hash = game.rangeVkeyCommitment().call().await?;
+    info!("Range Verification Key Hash:      {:?}", range_vk_hash);
+    info!("Game Range Verification Key Hash: {:?}", game_range_v_key_hash);
+    assert_eq!(range_vk_hash, game_range_v_key_hash, "Range verification key hash mismatch");
+
+    // 3. Generate the aggregation proof.
+    let network_prover =
+        ProverClient::builder().network_for(network_mode).signer(network_signer).build();
+    info!("Initialized network prover successfully");
+
+    let agg_proof_stdin = get_agg_proof_stdin(
+        vec![range_proof.proof],
+        vec![boot_info.clone()],
+        vec![l1_head.clone().into()],
+        &range_vk,
+        boot_info.l1Head,
+        wallet.address(),
+    )
+    .context("failed to get agg proof stdin")?;
+
+    let agg_proof_mode = match config.agg_proof_mode.to_lowercase().as_str() {
+        "groth16" => SP1ProofMode::Groth16,
+        "plonk" => SP1ProofMode::Plonk,
+        other => {
+            return Err(anyhow!(
+                "Invalid AGG_PROOF_MODE '{}'. Expected one of: plonk, groth16",
+                other
+            ))
+        }
+    };
+    info!("Aggregation proof mode: {:?}", agg_proof_mode);
+
+    let (agg_pk, agg_vk) = network_prover.setup(AGGREGATION_ELF);
+
+    let agg_vk_hash = agg_vk.bytes32();
+    let game_range_aggregation_v_key = game.aggregationVkey().call().await?.to_string();
+    info!("Aggregation Verification Key:      {:?}", range_vk_hash);
+    info!("Game Aggregation Verification Key: {}", game_range_aggregation_v_key);
+    assert_eq!(
+        agg_vk_hash, game_range_aggregation_v_key,
+        "Aggregation verification key hash mismatch"
+    );
+
+    let agg_proof = network_prover
+        .prove(&agg_pk, &agg_proof_stdin)
+        .mode(agg_proof_mode)
+        .strategy(config.agg_proof_strategy)
+        .run()
+        .unwrap();
+
+    let agg_proof_dir =
+        format!("data/{}/proofs/agg", data_fetcher.get_l2_chain_id().await.unwrap());
+    if !std::path::Path::new(&agg_proof_dir).exists() {
+        fs::create_dir_all(&agg_proof_dir).unwrap();
+    }
+
+    agg_proof.save(format!("{agg_proof_dir}/agg.bin")).expect("saving proof failed");
+    info!("Agg proof saved to {agg_proof_dir}/agg.bin");
+
+    // 4. Spin up anvil.
+    let fork_number = l1_head.number + 1;
+
+    let anvil =
+        Anvil::new().fork(config.l1_rpc).fork_block_number(fork_number).args(["--no-mining"]);
+    let anvil_instance = anvil.spawn();
+    let endpoint = anvil_instance.endpoint();
+    info!("Anvil chain started forked from L1 block number: {} at: {}", fork_number, endpoint);
+
+    // 5. Run the preflight check.
+    let provider_with_signer = ProviderBuilder::new()
+        .wallet(EthereumWallet::from(wallet))
+        .connect_http(Url::parse(&endpoint)?);
+
+    let game = OPSuccinctFaultDisputeGame::new(*game.address(), provider_with_signer.clone());
+
+    let tx = game.prove(agg_proof.bytes().into()).send().await?;
+
+    let client = provider_with_signer.client();
+    let _: String = client.request("evm_mine", Vec::<serde_json::Value>::new()).await?;
+
+    let block = provider_with_signer.get_block_by_number(BlockNumberOrTag::Latest).await?;
+    info!("Mined block: {}", block.unwrap().header.number);
+
+    let receipt = tx.get_receipt().await?;
+    info!("Transaction receipt: {:?}", receipt);
+
+    let claim_data = game.claimData().call().await?;
+    assert_eq!(claim_data.status, ProposalStatus::UnchallengedAndValidProofProvided);
+
+    info!("Prove dry-run completed successfully");
+
+    Ok(())
+}


### PR DESCRIPTION
This PR adds `prove-dryrun` command that creates a real proof for specified game and call `prove` with the proof in forked Anvil network.

This code is based on upstream preflight script (ref: https://github.com/celo-org/op-succinct/pull/68)