### PR TITLE
fix: install default ring crypto provider for challenger

### DIFF
--- a/fault-proof/bin/challenger.rs
+++ b/fault-proof/bin/challenger.rs
@@ -27,6 +27,8 @@ struct Args {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    rustls::crypto::ring::default_provider().install_default().unwrap();
+
     let args = Args::parse();
     dotenv::from_filename(args.env_file).ok();
 


### PR DESCRIPTION
Using Google KMS as a signer backend for the challenger seems to require setting a default crypto-provider similarly to what was added in the proposer's main function.

I also think that instead of calling this here and in the proposer, we could just enable `Rustls`'s `feature=ring` in the `Cargo.toml`:

This was the error message that made the process fail before this PR:
```

failed to setup env filter: FromEnvError { kind: Env(NotPresent) }


thread 'main' panicked at /usr/local/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rustls-0.23.35/src/crypto/mod.rs:249:14:


Could not automatically determine the process-level CryptoProvider from Rustls crate features.

Call CryptoProvider::install_default() before this point to select a provider manually, or make sure exactly one of the 'aws-lc-rs' and 'ring' features is enabled.

info
See the documentation of the CryptoProvider type for more information.
```