### PR TITLE
Game monitor delay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15212,6 +15212,11 @@ dependencies = [
 ]
 
 [[patch.unused]]
+name = "kona-rpc"
+version = "0.3.2"
+source = "git+https://github.com/celo-org/kona?rev=ce6c778e#ce6c778ed1ff3bba3910bd116e0db2f4bfe51d3a"
+
+[[patch.unused]]
 name = "alloy-eips"
 version = "1.1.3"
 source = "git+https://github.com/celo-org/alloy?rev=f88c10d3#f88c10d38df7e1247c8618abe0043516a14ee79f"
@@ -15220,8 +15225,3 @@ source = "git+https://github.com/celo-org/alloy?rev=f88c10d3#f88c10d38df7e1247c8
 name = "alloy-serde"
 version = "1.1.3"
 source = "git+https://github.com/celo-org/alloy?rev=f88c10d3#f88c10d38df7e1247c8618abe0043516a14ee79f"
-
-[[patch.unused]]
-name = "kona-rpc"
-version = "0.3.2"
-source = "git+https://github.com/celo-org/kona?rev=ce6c778e#ce6c778ed1ff3bba3910bd116e0db2f4bfe51d3a"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15212,11 +15212,6 @@ dependencies = [
 ]
 
 [[patch.unused]]
-name = "kona-rpc"
-version = "0.3.2"
-source = "git+https://github.com/celo-org/kona?rev=ce6c778e#ce6c778ed1ff3bba3910bd116e0db2f4bfe51d3a"
-
-[[patch.unused]]
 name = "alloy-eips"
 version = "1.1.3"
 source = "git+https://github.com/celo-org/alloy?rev=f88c10d3#f88c10d38df7e1247c8618abe0043516a14ee79f"
@@ -15225,3 +15220,8 @@ source = "git+https://github.com/celo-org/alloy?rev=f88c10d3#f88c10d38df7e1247c8
 name = "alloy-serde"
 version = "1.1.3"
 source = "git+https://github.com/celo-org/alloy?rev=f88c10d3#f88c10d38df7e1247c8618abe0043516a14ee79f"
+
+[[patch.unused]]
+name = "kona-rpc"
+version = "0.3.2"
+source = "git+https://github.com/celo-org/kona?rev=ce6c778e#ce6c778ed1ff3bba3910bd116e0db2f4bfe51d3a"

--- a/scripts/utils/bin/game_monitor.rs
+++ b/scripts/utils/bin/game_monitor.rs
@@ -5,7 +5,7 @@ use clap::Parser;
 use fault_proof::contract::{
     DisputeGameFactory::DisputeGameFactoryInstance, OPSuccinctFaultDisputeGame,
 };
-use log::{error, info, warn};
+use log::{error, info};
 use std::{
     collections::{HashMap, VecDeque},
     env,

--- a/scripts/utils/bin/game_monitor.rs
+++ b/scripts/utils/bin/game_monitor.rs
@@ -359,7 +359,16 @@ async fn main() -> Result<()> {
         }
 
         // Discover new game indices and queue them for deferred processing.
-        let current_game_count = factory.gameCount().call().await?.to::<u64>();
+        let current_game_count = match factory.gameCount().call().await {
+            Ok(count) => count.to::<u64>(),
+            Err(e) => {
+                error!(
+                    "Failed to Fetch gameCount from factory {}: {}. Retrying",
+                    dispute_game_factory_address, e
+                );
+                continue;
+            }
+        };
         while state.next_game_index < current_game_count {
             let game_index = state.next_game_index;
             state.next_game_index += 1;

--- a/scripts/utils/bin/game_monitor.rs
+++ b/scripts/utils/bin/game_monitor.rs
@@ -7,7 +7,7 @@ use fault_proof::contract::{
 };
 use log::{error, info, warn};
 use std::{
-    collections::{HashMap, HashSet, VecDeque},
+    collections::{HashMap, VecDeque},
     env,
     fs::{self, File},
     io::Write,
@@ -20,6 +20,7 @@ use tokio::time::sleep;
 const GAME_TYPE: u32 = 42;
 // How long should we let a cost estimator run before killing it?
 const VALID_ESTIMATOR_DURATION_IN_SECONDS: u64 = 60 * 60 * 3; // 3 hours
+const MAX_RETRIES: u32 = 3;
 
 /// Arguments for the game monitor.
 #[derive(Debug, Clone, Parser)]
@@ -64,10 +65,11 @@ pub struct GameMonitorArgs {
     #[arg(long, default_value = None)]
     pub start_index: Option<u64>,
 
-    /// The time in seconds to wait between seeing a game and running the cost estimator for a
-    /// game. This exists to mitigate node-desync issues. Which can occur when we access the L2
-    /// via a proxy with multiple backends. The default value of 10 minutes is a value that
-    /// should be safe given the default values used when running op stack nodes.
+    /// The time in seconds to wait between discovering a game index and fetching its details
+    /// from L1/L2. This delay mitigates node-desync issues that occur when accessing L1 or L2
+    /// via a proxy with multiple backends (e.g. gameCount sees a game on one backend but
+    /// gameAtIndex fails on another). The default value of 10 minutes should be safe given the
+    /// default values used when running op stack nodes.
     #[arg(long, default_value = "600")]
     pub delay: u64,
 }
@@ -79,32 +81,23 @@ struct RunningEstimator {
     log_file: PathBuf,
 }
 
-/// A game that has been discovered but is waiting for its delay to elapse before
-/// spawning the cost estimator.
+/// A game index discovered from the factory, waiting for its delay to elapse before
+/// fetching game details and spawning the cost estimator.
 struct PendingGame {
     discovered_at: Instant,
     game_index: u64,
-    game_address: Address,
-    start_block: u64,
-    end_block: u64,
+    retries: u32,
 }
 
-/// Tracks the state of the game monitor.
 struct MonitorState {
-    /// Set of game addresses we've already seen.
-    processed_games: HashSet<Address>,
-    /// Currently running estimator processes.
     running_processes: HashMap<u64, RunningEstimator>,
-    /// Games waiting for their delay to elapse before spawning.
     pending_games: VecDeque<PendingGame>,
-    /// The next game index to check.
     next_game_index: u64,
 }
 
 impl MonitorState {
     fn new(next_game_index: u64) -> Self {
         Self {
-            processed_games: HashSet::new(),
             running_processes: HashMap::new(),
             pending_games: VecDeque::new(),
             next_game_index,
@@ -157,63 +150,6 @@ impl MonitorState {
     /// Check if we can spawn a new process.
     fn can_spawn_new(&self, max_concurrent: usize) -> bool {
         self.running_processes.len() < max_concurrent
-    }
-
-    /// Spawn pending games whose delay has elapsed, respecting the concurrency limit.
-    ///
-    /// Games are spawned in discovery order (FIFO). Since all games share the same delay,
-    /// we can stop at the first game that isn't ready yet.
-    fn spawn_ready_games(
-        &mut self,
-        delay: Duration,
-        max_concurrent: usize,
-        cost_estimator_binary_path: &PathBuf,
-        env_file: &Path,
-        logs_dir: &Path,
-    ) {
-        while let Some(pending) = self.pending_games.front() {
-            if !self.can_spawn_new(max_concurrent) {
-                break;
-            }
-            if pending.discovered_at.elapsed() < delay {
-                break;
-            }
-
-            let pending = self.pending_games.pop_front().unwrap();
-            let log_file = logs_dir.join(format!(
-                "cost-estimator-{}-{}.log",
-                pending.game_index, pending.game_address
-            ));
-
-            match spawn_cost_estimator(
-                cost_estimator_binary_path,
-                env_file,
-                &log_file,
-                pending.start_block,
-                pending.end_block,
-                pending.end_block - pending.start_block,
-            ) {
-                Ok(child) => {
-                    info!(
-                        "Started cost estimator {} for game {} (blocks {}-{})",
-                        pending.game_index,
-                        pending.game_address,
-                        pending.start_block,
-                        pending.end_block
-                    );
-                    self.running_processes.insert(
-                        pending.game_index,
-                        RunningEstimator { started_at: Instant::now(), process: child, log_file },
-                    );
-                }
-                Err(e) => {
-                    error!(
-                        "Failed to spawn cost estimator for game {}: {}",
-                        pending.game_address, e
-                    );
-                }
-            }
-        }
     }
 }
 
@@ -342,25 +278,35 @@ async fn main() -> Result<()> {
             state.pending_games.len()
         );
 
-        // Spawn any pending games whose delay has elapsed
-        state.spawn_ready_games(
-            delay,
-            args.max_concurrent,
-            &args.cost_estimator_binary_path,
-            &args.env_file,
-            &args.logs_dir,
-        );
+        // Process pending games whose delay has elapsed: fetch game info and spawn.
+        while let Some(pending) = state.pending_games.front() {
+            if !state.can_spawn_new(args.max_concurrent) {
+                break;
+            }
+            if pending.discovered_at.elapsed() < delay {
+                break;
+            }
 
-        // Detect new games and queue them for deferred spawning
-        let current_game_count = factory.gameCount().call().await?.to::<u64>();
-        while state.next_game_index < current_game_count {
-            let game_index = state.next_game_index;
-            state.next_game_index += 1;
+            let mut pending = state.pending_games.pop_front().unwrap();
+            let game_index = pending.game_index;
 
             let game_info = match factory.gameAtIndex(U256::from(game_index)).call().await {
                 Ok(info) => info,
                 Err(e) => {
-                    error!("Failed to get game at index {}: {}", game_index, e);
+                    if pending.retries < MAX_RETRIES {
+                        pending.retries += 1;
+                        pending.discovered_at = Instant::now();
+                        warn!(
+                            "Failed to get game at index {}: {}. Retry {}/{}",
+                            game_index, e, pending.retries, MAX_RETRIES
+                        );
+                        state.pending_games.push_back(pending);
+                    } else {
+                        error!(
+                            "Failed to get game at index {} after {} retries: {}. Skipping.",
+                            game_index, MAX_RETRIES, e
+                        );
+                    }
                     continue;
                 }
             };
@@ -370,25 +316,33 @@ async fn main() -> Result<()> {
 
             if game_type != GAME_TYPE {
                 info!(
-                    "Skipping game {} at index {} (type {} != {})",
-                    game_address, game_index, game_type, GAME_TYPE
+                    "Skipping game at index {} (type {} != {})",
+                    game_index, game_type, GAME_TYPE
                 );
                 continue;
             }
 
-            if state.processed_games.contains(&game_address) {
-                info!("Already processed game {}, skipping", game_address);
-                continue;
-            }
-
-            info!("Found new game of type {} at index {}: {}", game_type, game_index, game_address);
+            info!("Processing game {} at index {}", game_address, game_index);
 
             let game = OPSuccinctFaultDisputeGame::new(game_address, l1_provider.clone());
 
             let l2_block_number = match game.l2BlockNumber().call().await {
                 Ok(block) => block.to::<u64>(),
                 Err(e) => {
-                    error!("Failed to get L2 block number for game {}: {}", game_address, e);
+                    if pending.retries < MAX_RETRIES {
+                        pending.retries += 1;
+                        pending.discovered_at = Instant::now();
+                        warn!(
+                            "Failed to get L2 block number for game {} at index {}: {}. Retry {}/{}",
+                            game_address, game_index, e, pending.retries, MAX_RETRIES
+                        );
+                        state.pending_games.push_back(pending);
+                    } else {
+                        error!(
+                            "Failed to get L2 block number for game {} after {} retries: {}. Skipping.",
+                            game_address, MAX_RETRIES, e
+                        );
+                    }
                     continue;
                 }
             };
@@ -396,7 +350,10 @@ async fn main() -> Result<()> {
             let start_block = match game.startingBlockNumber().call().await {
                 Ok(block) => block.to::<u64>(),
                 Err(e) => {
-                    warn!("Failed to get starting block number for game {}: {}", game_address, e);
+                    warn!(
+                        "Failed to get starting block number for game {}: {}",
+                        game_address, e
+                    );
                     0
                 }
             };
@@ -404,16 +361,57 @@ async fn main() -> Result<()> {
 
             info!("Game {} covers L2 blocks {} to {}", game_address, start_block, end_block);
 
-            state.processed_games.insert(game_address);
+            let log_file = args.logs_dir.join(format!(
+                "cost-estimator-{}-{}.log",
+                game_index, game_address
+            ));
+
+            match spawn_cost_estimator(
+                &args.cost_estimator_binary_path,
+                &args.env_file,
+                &log_file,
+                start_block,
+                end_block,
+                end_block - start_block,
+            ) {
+                Ok(child) => {
+                    info!(
+                        "Started cost estimator for game {} at index {} (blocks {}-{})",
+                        game_address, game_index, start_block, end_block
+                    );
+                    state.running_processes.insert(
+                        game_index,
+                        RunningEstimator {
+                            started_at: Instant::now(),
+                            process: child,
+                            log_file,
+                        },
+                    );
+                }
+                Err(e) => {
+                    error!(
+                        "Failed to spawn cost estimator for game {}: {}",
+                        game_address, e
+                    );
+                }
+            }
+        }
+
+        // Discover new game indices and queue them for deferred processing.
+        let current_game_count = factory.gameCount().call().await?.to::<u64>();
+        while state.next_game_index < current_game_count {
+            let game_index = state.next_game_index;
+            state.next_game_index += 1;
+
+            info!(
+                "Discovered new game at index {}, queuing for processing after {:?} delay",
+                game_index, delay
+            );
             state.pending_games.push_back(PendingGame {
                 discovered_at: Instant::now(),
                 game_index,
-                game_address,
-                start_block,
-                end_block,
+                retries: 0,
             });
-
-            info!("Queued game {} for cost estimation after {:?} delay", game_address, delay);
         }
 
         sleep(poll_interval).await;

--- a/scripts/utils/bin/game_monitor.rs
+++ b/scripts/utils/bin/game_monitor.rs
@@ -7,7 +7,7 @@ use fault_proof::contract::{
 };
 use log::{error, info, warn};
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{HashMap, HashSet, VecDeque},
     env,
     fs::{self, File},
     io::Write,
@@ -79,19 +79,36 @@ struct RunningEstimator {
     log_file: PathBuf,
 }
 
+/// A game that has been discovered but is waiting for its delay to elapse before
+/// spawning the cost estimator.
+struct PendingGame {
+    discovered_at: Instant,
+    game_index: u64,
+    game_address: Address,
+    start_block: u64,
+    end_block: u64,
+}
+
 /// Tracks the state of the game monitor.
 struct MonitorState {
-    /// Set of game addresses we've already spawned estimators for.
+    /// Set of game addresses we've already seen.
     processed_games: HashSet<Address>,
     /// Currently running estimator processes.
     running_processes: HashMap<u64, RunningEstimator>,
+    /// Games waiting for their delay to elapse before spawning.
+    pending_games: VecDeque<PendingGame>,
     /// The next game index to check.
     next_game_index: u64,
 }
 
 impl MonitorState {
     fn new(next_game_index: u64) -> Self {
-        Self { processed_games: HashSet::new(), running_processes: HashMap::new(), next_game_index }
+        Self {
+            processed_games: HashSet::new(),
+            running_processes: HashMap::new(),
+            pending_games: VecDeque::new(),
+            next_game_index,
+        }
     }
 
     /// Clean up finished processes and return their results.
@@ -141,6 +158,67 @@ impl MonitorState {
     fn can_spawn_new(&self, max_concurrent: usize) -> bool {
         self.running_processes.len() < max_concurrent
     }
+
+    /// Spawn pending games whose delay has elapsed, respecting the concurrency limit.
+    ///
+    /// Games are spawned in discovery order (FIFO). Since all games share the same delay,
+    /// we can stop at the first game that isn't ready yet.
+    fn spawn_ready_games(
+        &mut self,
+        delay: Duration,
+        max_concurrent: usize,
+        cost_estimator_binary_path: &PathBuf,
+        env_file: &Path,
+        logs_dir: &Path,
+    ) {
+        while let Some(pending) = self.pending_games.front() {
+            if !self.can_spawn_new(max_concurrent) {
+                break;
+            }
+            if pending.discovered_at.elapsed() < delay {
+                break;
+            }
+
+            let pending = self.pending_games.pop_front().unwrap();
+            let log_file = logs_dir.join(format!(
+                "cost-estimator-{}-{}.log",
+                pending.game_index, pending.game_address
+            ));
+
+            match spawn_cost_estimator(
+                cost_estimator_binary_path,
+                env_file,
+                &log_file,
+                pending.start_block,
+                pending.end_block,
+                pending.end_block - pending.start_block,
+            ) {
+                Ok(child) => {
+                    info!(
+                        "Started cost estimator {} for game {} (blocks {}-{})",
+                        pending.game_index,
+                        pending.game_address,
+                        pending.start_block,
+                        pending.end_block
+                    );
+                    self.running_processes.insert(
+                        pending.game_index,
+                        RunningEstimator {
+                            started_at: Instant::now(),
+                            process: child,
+                            log_file,
+                        },
+                    );
+                }
+                Err(e) => {
+                    error!(
+                        "Failed to spawn cost estimator for game {}: {}",
+                        pending.game_address, e
+                    );
+                }
+            }
+        }
+    }
 }
 
 /// Spawns a cost estimator process for the given block range.
@@ -151,7 +229,6 @@ fn spawn_cost_estimator(
     start_block: u64,
     end_block: u64,
     batch_size: u64,
-    delay: Duration,
 ) -> Result<Child> {
     let args = [
         "--start",
@@ -193,10 +270,8 @@ fn spawn_cost_estimator(
     let stdout_file = log_file_handle.try_clone()?;
     let stderr_file = log_file_handle.try_clone()?;
 
-    info!("Waiting {:?} before running cost estimator", delay);
-    std::thread::sleep(delay);
-    info!("Running cost estimator:: {}", cmd);
-    info!("Logging to: {:}", log_file.display());
+    info!("Running cost estimator: {}", cmd);
+    info!("Logging to: {}", log_file.display());
 
     let child = Command::new(cost_estimator_binary_path)
         .args(args)
@@ -258,120 +333,102 @@ async fn main() -> Result<()> {
     let mut state = MonitorState::new(next_game_index);
 
     let poll_interval = Duration::from_secs(args.poll_interval);
+    let delay = Duration::from_secs(args.delay);
+
     // Main monitoring loop
     loop {
-        // Clean up any finished processes
         state.cleanup_finished_processes();
 
-        info!("Running processes: {}/{}", state.running_processes.len(), args.max_concurrent);
-        // Get current game count
+        info!(
+            "Running: {}/{}, Pending: {}",
+            state.running_processes.len(),
+            args.max_concurrent,
+            state.pending_games.len()
+        );
+
+        // Spawn any pending games whose delay has elapsed
+        state.spawn_ready_games(
+            delay,
+            args.max_concurrent,
+            &args.cost_estimator_binary_path,
+            &args.env_file,
+            &args.logs_dir,
+        );
+
+        // Detect new games and queue them for deferred spawning
         let current_game_count = factory.gameCount().call().await?.to::<u64>();
-        if state.can_spawn_new(args.max_concurrent) {
-            // Check for new games
+        while state.next_game_index < current_game_count {
             let game_index = state.next_game_index;
-            if current_game_count > game_index {
-                state.next_game_index = game_index + 1;
-                // Get game info
-                let game_info = match factory.gameAtIndex(U256::from(game_index)).call().await {
-                    Ok(info) => info,
-                    Err(e) => {
-                        error!("Failed to get game at index {}: {}", game_index, e);
-                        continue;
-                    }
-                };
+            state.next_game_index += 1;
 
-                let game_type = game_info.gameType;
-                let game_address = game_info.proxy;
-                // Check if it's the game type we're monitoring
-                if game_type != GAME_TYPE {
-                    info!(
-                        "Skipping game {} at index {} (type {} != {})",
-                        game_address, game_index, game_type, GAME_TYPE
-                    );
+            let game_info = match factory.gameAtIndex(U256::from(game_index)).call().await {
+                Ok(info) => info,
+                Err(e) => {
+                    error!("Failed to get game at index {}: {}", game_index, e);
                     continue;
                 }
+            };
 
-                // Check if we've already processed this game
-                if state.processed_games.contains(&game_address) {
-                    info!("Already processed game {}, skipping", game_address);
-                    continue;
-                }
+            let game_type = game_info.gameType;
+            let game_address = game_info.proxy;
 
+            if game_type != GAME_TYPE {
                 info!(
-                    "Found new game of type {} at index {}: {}",
-                    game_type, game_index, game_address
+                    "Skipping game {} at index {} (type {} != {})",
+                    game_address, game_index, game_type, GAME_TYPE
                 );
-
-                // Get the game contract
-                let game = OPSuccinctFaultDisputeGame::new(game_address, l1_provider.clone());
-
-                // Get the L2 block number for this game
-                let l2_block_number = match game.l2BlockNumber().call().await {
-                    Ok(block) => block.to::<u64>(),
-                    Err(e) => {
-                        error!("Failed to get L2 block number for game {}: {}", game_address, e);
-                        continue;
-                    }
-                };
-
-                // Get the start block from the game contract
-                let start_block = match game.startingBlockNumber().call().await {
-                    Ok(block) => block.to::<u64>(),
-                    Err(e) => {
-                        warn!(
-                            "Failed to get starting block number for game {}: {}",
-                            game_address, e
-                        );
-                        0
-                    }
-                };
-                let end_block = l2_block_number;
-
-                info!("Game {} covers L2 blocks {} to {}", game_address, start_block, end_block);
-
-                let mut log_file =
-                    PathBuf::from(format!("cost-estimator-{}-{}.log", game_index, game_address));
-                log_file = args.logs_dir.join(log_file);
-                // Spawn the cost estimator process
-                match spawn_cost_estimator(
-                    &args.cost_estimator_binary_path,
-                    &args.env_file,
-                    &log_file,
-                    start_block,
-                    end_block,
-                    end_block - start_block,
-                    Duration::from_secs(args.delay),
-                ) {
-                    Ok(child) => {
-                        info!(
-                            "Started cost estimator {} for game {} (blocks {}-{})",
-                            game_index, game_address, start_block, end_block
-                        );
-
-                        state.running_processes.insert(
-                            game_index,
-                            RunningEstimator {
-                                started_at: Instant::now(),
-                                process: child,
-                                log_file,
-                            },
-                        );
-                        state.processed_games.insert(game_address);
-                    }
-                    Err(e) => {
-                        error!("Failed to spawn cost estimator for game {}: {}", game_address, e);
-                    }
-                }
+                continue;
             }
-        } else {
-            info!("Max concurrent processes reached, waiting for one to finish...");
+
+            if state.processed_games.contains(&game_address) {
+                info!("Already processed game {}, skipping", game_address);
+                continue;
+            }
+
+            info!(
+                "Found new game of type {} at index {}: {}",
+                game_type, game_index, game_address
+            );
+
+            let game = OPSuccinctFaultDisputeGame::new(game_address, l1_provider.clone());
+
+            let l2_block_number = match game.l2BlockNumber().call().await {
+                Ok(block) => block.to::<u64>(),
+                Err(e) => {
+                    error!("Failed to get L2 block number for game {}: {}", game_address, e);
+                    continue;
+                }
+            };
+
+            let start_block = match game.startingBlockNumber().call().await {
+                Ok(block) => block.to::<u64>(),
+                Err(e) => {
+                    warn!(
+                        "Failed to get starting block number for game {}: {}",
+                        game_address, e
+                    );
+                    0
+                }
+            };
+            let end_block = l2_block_number;
+
+            info!("Game {} covers L2 blocks {} to {}", game_address, start_block, end_block);
+
+            state.processed_games.insert(game_address);
+            state.pending_games.push_back(PendingGame {
+                discovered_at: Instant::now(),
+                game_index,
+                game_address,
+                start_block,
+                end_block,
+            });
+
+            info!(
+                "Queued game {} for cost estimation after {:?} delay",
+                game_address, delay
+            );
         }
 
-        // If there are no more games to process or we don't have any capacity to spawn a new
-        // process then wait.
-        if state.next_game_index >= current_game_count || !state.can_spawn_new(args.max_concurrent)
-        {
-            sleep(poll_interval).await;
-        }
+        sleep(poll_interval).await;
     }
 }

--- a/scripts/utils/bin/game_monitor.rs
+++ b/scripts/utils/bin/game_monitor.rs
@@ -286,10 +286,7 @@ async fn main() -> Result<()> {
             let game_info = match factory.gameAtIndex(U256::from(game_index)).call().await {
                 Ok(info) => info,
                 Err(e) => {
-                    error!(
-                        "Failed to get game at index {}: {}. Skipping.",
-                        game_index, e
-                    );
+                    error!("Failed to get game at index {}: {}. Skipping.", game_index, e);
                     continue;
                 }
             };
@@ -368,10 +365,9 @@ async fn main() -> Result<()> {
                 "Discovered new game at index {}, queuing for processing after {:?} delay",
                 game_index, delay
             );
-            state.pending_games.push_back(PendingGame {
-                discovered_at: Instant::now(),
-                game_index,
-            });
+            state
+                .pending_games
+                .push_back(PendingGame { discovered_at: Instant::now(), game_index });
         }
 
         sleep(poll_interval).await;

--- a/scripts/utils/bin/game_monitor.rs
+++ b/scripts/utils/bin/game_monitor.rs
@@ -97,11 +97,7 @@ struct MonitorState {
 
 impl MonitorState {
     fn new(next_game_index: u64) -> Self {
-        Self {
-            running_processes: HashMap::new(),
-            pending_games: VecDeque::new(),
-            next_game_index,
-        }
+        Self { running_processes: HashMap::new(), pending_games: VecDeque::new(), next_game_index }
     }
 
     /// Clean up finished processes and return their results.
@@ -350,10 +346,7 @@ async fn main() -> Result<()> {
             let start_block = match game.startingBlockNumber().call().await {
                 Ok(block) => block.to::<u64>(),
                 Err(e) => {
-                    warn!(
-                        "Failed to get starting block number for game {}: {}",
-                        game_address, e
-                    );
+                    warn!("Failed to get starting block number for game {}: {}", game_address, e);
                     0
                 }
             };
@@ -361,10 +354,8 @@ async fn main() -> Result<()> {
 
             info!("Game {} covers L2 blocks {} to {}", game_address, start_block, end_block);
 
-            let log_file = args.logs_dir.join(format!(
-                "cost-estimator-{}-{}.log",
-                game_index, game_address
-            ));
+            let log_file =
+                args.logs_dir.join(format!("cost-estimator-{}-{}.log", game_index, game_address));
 
             match spawn_cost_estimator(
                 &args.cost_estimator_binary_path,
@@ -381,18 +372,11 @@ async fn main() -> Result<()> {
                     );
                     state.running_processes.insert(
                         game_index,
-                        RunningEstimator {
-                            started_at: Instant::now(),
-                            process: child,
-                            log_file,
-                        },
+                        RunningEstimator { started_at: Instant::now(), process: child, log_file },
                     );
                 }
                 Err(e) => {
-                    error!(
-                        "Failed to spawn cost estimator for game {}: {}",
-                        game_address, e
-                    );
+                    error!("Failed to spawn cost estimator for game {}: {}", game_address, e);
                 }
             }
         }

--- a/scripts/utils/bin/game_monitor.rs
+++ b/scripts/utils/bin/game_monitor.rs
@@ -20,8 +20,6 @@ use tokio::time::sleep;
 const GAME_TYPE: u32 = 42;
 // How long should we let a cost estimator run before killing it?
 const VALID_ESTIMATOR_DURATION_IN_SECONDS: u64 = 60 * 60 * 3; // 3 hours
-const MAX_RETRIES: u32 = 3;
-
 /// Arguments for the game monitor.
 #[derive(Debug, Clone, Parser)]
 pub struct GameMonitorArgs {
@@ -86,7 +84,6 @@ struct RunningEstimator {
 struct PendingGame {
     discovered_at: Instant,
     game_index: u64,
-    retries: u32,
 }
 
 struct MonitorState {
@@ -283,26 +280,16 @@ async fn main() -> Result<()> {
                 break;
             }
 
-            let mut pending = state.pending_games.pop_front().unwrap();
+            let pending = state.pending_games.pop_front().unwrap();
             let game_index = pending.game_index;
 
             let game_info = match factory.gameAtIndex(U256::from(game_index)).call().await {
                 Ok(info) => info,
                 Err(e) => {
-                    if pending.retries < MAX_RETRIES {
-                        pending.retries += 1;
-                        pending.discovered_at = Instant::now();
-                        warn!(
-                            "Failed to get game at index {}: {}. Retry {}/{}",
-                            game_index, e, pending.retries, MAX_RETRIES
-                        );
-                        state.pending_games.push_back(pending);
-                    } else {
-                        error!(
-                            "Failed to get game at index {} after {} retries: {}. Skipping.",
-                            game_index, MAX_RETRIES, e
-                        );
-                    }
+                    error!(
+                        "Failed to get game at index {}: {}. Skipping.",
+                        game_index, e
+                    );
                     continue;
                 }
             };
@@ -325,20 +312,10 @@ async fn main() -> Result<()> {
             let l2_block_number = match game.l2BlockNumber().call().await {
                 Ok(block) => block.to::<u64>(),
                 Err(e) => {
-                    if pending.retries < MAX_RETRIES {
-                        pending.retries += 1;
-                        pending.discovered_at = Instant::now();
-                        warn!(
-                            "Failed to get L2 block number for game {} at index {}: {}. Retry {}/{}",
-                            game_address, game_index, e, pending.retries, MAX_RETRIES
-                        );
-                        state.pending_games.push_back(pending);
-                    } else {
-                        error!(
-                            "Failed to get L2 block number for game {} after {} retries: {}. Skipping.",
-                            game_address, MAX_RETRIES, e
-                        );
-                    }
+                    error!(
+                        "Failed to get L2 block number for game {} at index {}: {}. Skipping.",
+                        game_address, game_index, e
+                    );
                     continue;
                 }
             };
@@ -394,7 +371,6 @@ async fn main() -> Result<()> {
             state.pending_games.push_back(PendingGame {
                 discovered_at: Instant::now(),
                 game_index,
-                retries: 0,
             });
         }
 

--- a/scripts/utils/bin/game_monitor.rs
+++ b/scripts/utils/bin/game_monitor.rs
@@ -320,8 +320,11 @@ async fn main() -> Result<()> {
             let start_block = match game.startingBlockNumber().call().await {
                 Ok(block) => block.to::<u64>(),
                 Err(e) => {
-                    warn!("Failed to get starting block number for game {}: {}", game_address, e);
-                    0
+                    error!(
+                        "Failed to get staring block number for game {} at index {}: {}. Skipping.",
+                        game_address, game_index, e
+                    );
+                    continue;
                 }
             };
             let end_block = l2_block_number;

--- a/scripts/utils/bin/game_monitor.rs
+++ b/scripts/utils/bin/game_monitor.rs
@@ -203,11 +203,7 @@ impl MonitorState {
                     );
                     self.running_processes.insert(
                         pending.game_index,
-                        RunningEstimator {
-                            started_at: Instant::now(),
-                            process: child,
-                            log_file,
-                        },
+                        RunningEstimator { started_at: Instant::now(), process: child, log_file },
                     );
                 }
                 Err(e) => {
@@ -385,10 +381,7 @@ async fn main() -> Result<()> {
                 continue;
             }
 
-            info!(
-                "Found new game of type {} at index {}: {}",
-                game_type, game_index, game_address
-            );
+            info!("Found new game of type {} at index {}: {}", game_type, game_index, game_address);
 
             let game = OPSuccinctFaultDisputeGame::new(game_address, l1_provider.clone());
 
@@ -403,10 +396,7 @@ async fn main() -> Result<()> {
             let start_block = match game.startingBlockNumber().call().await {
                 Ok(block) => block.to::<u64>(),
                 Err(e) => {
-                    warn!(
-                        "Failed to get starting block number for game {}: {}",
-                        game_address, e
-                    );
+                    warn!("Failed to get starting block number for game {}: {}", game_address, e);
                     0
                 }
             };
@@ -423,10 +413,7 @@ async fn main() -> Result<()> {
                 end_block,
             });
 
-            info!(
-                "Queued game {} for cost estimation after {:?} delay",
-                game_address, delay
-            );
+            info!("Queued game {} for cost estimation after {:?} delay", game_address, delay);
         }
 
         sleep(poll_interval).await;


### PR DESCRIPTION
This is used to mitigate inconsistent finalized blocks being retrieved from proxied L1/L2 rpcs with multiple backends.

Adding the delay allows for a window, whithin which nodes can be out of sync, without impacting the game monitor.

The default delay is 10m.

Relates to https://github.com/celo-org/celo-blockchain-planning/issues/1275