### PR TITLE
Proposer: split proof ranges

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9043,6 +9043,7 @@ dependencies = [
  "celo-alloy-rpc-types",
  "clap",
  "dotenv",
+ "futures",
  "hex",
  "op-alloy-network",
  "op-alloy-rpc-types",
@@ -9054,6 +9055,7 @@ dependencies = [
  "op-succinct-proof-utils",
  "op-succinct-signer-utils",
  "rand 0.9.2",
+ "rstest",
  "rustls 0.23.35",
  "serde",
  "serde_json",
@@ -10877,6 +10879,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "rend"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11848,6 +11856,35 @@ dependencies = [
  "revm-primitives",
  "revm-state",
  "serde",
+]
+
+[[package]]
+name = "rstest"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate 3.4.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version 0.4.1",
+ "syn 2.0.109",
+ "unicode-ident",
 ]
 
 [[package]]

--- a/book/fault_proofs/proposer.md
+++ b/book/fault_proofs/proposer.md
@@ -97,6 +97,8 @@ Depending on the one you choose, you must provide the corresponding environment 
 | `TIMEOUT` | The timeout to use for proving (in seconds). | `14,400` (4 hours) |
 | `RANGE_CYCLE_LIMIT` | The cycle limit to use for range proofs. | `1,000,000,000,000` |
 | `RANGE_GAS_LIMIT` | The gas limit to use for range proofs. | `1,000,000,000,000` |
+| `RANGE_SPLIT_COUNT` | The number of splits to use for range proofs. | `1` |
+| `MAX_CONCURRENT_RANGE_PROOFS` | The maximum number of concurrent range proof tasks. | `1` |
 | `AGG_CYCLE_LIMIT` | The cycle limit to use for aggregation proofs. | `1,000,000,000,000` |
 | `AGG_GAS_LIMIT` | The gas limit to use for aggregation proofs. | `1,000,000,000,000` |
 | `WHITELIST` | The list of prover addresses that are allowed to bid on proof requests. | `` |

--- a/fault-proof/Cargo.toml
+++ b/fault-proof/Cargo.toml
@@ -27,49 +27,50 @@ op-succinct-ethereum-host-utils.workspace = true
 op-succinct-host-utils.workspace = true
 op-succinct-proof-utils.workspace = true
 op-succinct-signer-utils.workspace = true
-
-# sp1
 sp1-sdk.workspace = true
-
-# alloy
 alloy-contract.workspace = true
 alloy-eips.workspace = true
 alloy-network.workspace = true
 alloy-primitives.workspace = true
-alloy-provider = { workspace = true, features = ["reqwest"] }
 alloy-rpc-types-eth.workspace = true
 alloy-rpc-types-trace.workspace = true
 alloy-sol-macro.workspace = true
 alloy-sol-types.workspace = true
+op-alloy-network.workspace = true
+op-alloy-rpc-types.workspace = true
+celo-alloy-network.workspace = true
+celo-alloy-rpc-types.workspace = true
+anyhow.workspace = true
+async-trait.workspace = true
+dotenv.workspace = true
+futures.workspace = true
+serde.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+hex.workspace = true
+strum_macros.workspace = true
+serde_json.workspace = true
+
+# sp1
+
+# alloy
+alloy-provider = { workspace = true, features = ["reqwest"] }
 alloy-transport-http = { workspace = true, features = [
     "reqwest",
     "reqwest-native-tls",
 ] }
 
 # op-alloy
-op-alloy-network.workspace = true
-op-alloy-rpc-types.workspace = true
 
 # celo-alloy
-celo-alloy-network.workspace = true
-celo-alloy-rpc-types.workspace = true
 
 # general
-anyhow.workspace = true
-async-trait.workspace = true
 clap = { workspace = true, features = ["derive"] }
-dotenv.workspace = true
 rand = "0.9"
-serde.workspace = true
-tokio.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
-tracing.workspace = true
-hex.workspace = true
 strum = { workspace = true, features = ["derive"] }
-strum_macros.workspace = true
 tikv-jemallocator = "0.6.0"
 rustls = "0.23.23"
-serde_json.workspace = true
 
 [dev-dependencies]
 alloy-signer-local.workspace = true
@@ -79,6 +80,7 @@ op-succinct-bindings.workspace = true
 serde_json.workspace = true
 serde.workspace = true
 alloy-rpc-types-trace.workspace = true
+rstest = "0.26"
 which = "4.4"
 
 [features]

--- a/fault-proof/Cargo.toml
+++ b/fault-proof/Cargo.toml
@@ -27,50 +27,50 @@ op-succinct-ethereum-host-utils.workspace = true
 op-succinct-host-utils.workspace = true
 op-succinct-proof-utils.workspace = true
 op-succinct-signer-utils.workspace = true
+
+# sp1
 sp1-sdk.workspace = true
+
+# alloy
 alloy-contract.workspace = true
 alloy-eips.workspace = true
 alloy-network.workspace = true
 alloy-primitives.workspace = true
+alloy-provider = { workspace = true, features = ["reqwest"] }
 alloy-rpc-types-eth.workspace = true
 alloy-rpc-types-trace.workspace = true
 alloy-sol-macro.workspace = true
 alloy-sol-types.workspace = true
-op-alloy-network.workspace = true
-op-alloy-rpc-types.workspace = true
-celo-alloy-network.workspace = true
-celo-alloy-rpc-types.workspace = true
-anyhow.workspace = true
-async-trait.workspace = true
-dotenv.workspace = true
-futures.workspace = true
-serde.workspace = true
-tokio.workspace = true
-tracing.workspace = true
-hex.workspace = true
-strum_macros.workspace = true
-serde_json.workspace = true
-
-# sp1
-
-# alloy
-alloy-provider = { workspace = true, features = ["reqwest"] }
 alloy-transport-http = { workspace = true, features = [
     "reqwest",
     "reqwest-native-tls",
 ] }
 
 # op-alloy
+op-alloy-network.workspace = true
+op-alloy-rpc-types.workspace = true
 
 # celo-alloy
+celo-alloy-network.workspace = true
+celo-alloy-rpc-types.workspace = true
 
 # general
+anyhow.workspace = true
+async-trait.workspace = true
 clap = { workspace = true, features = ["derive"] }
+dotenv.workspace = true
+futures.workspace = true
 rand = "0.9"
+serde.workspace = true
+tokio.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
+tracing.workspace = true
+hex.workspace = true
 strum = { workspace = true, features = ["derive"] }
+strum_macros.workspace = true
 tikv-jemallocator = "0.6.0"
 rustls = "0.23.23"
+serde_json.workspace = true
 
 [dev-dependencies]
 alloy-signer-local.workspace = true

--- a/fault-proof/bin/proposer.rs
+++ b/fault-proof/bin/proposer.rs
@@ -40,6 +40,7 @@ async fn main() -> Result<()> {
     setup_logger();
 
     let proposer_config = ProposerConfig::from_env()?;
+
     let proposer_signer = SignerLock::from_env().await?;
 
     let l1_provider =

--- a/fault-proof/src/config.rs
+++ b/fault-proof/src/config.rs
@@ -1,8 +1,12 @@
-use std::{env, str::FromStr};
+use std::{
+    env,
+    num::{NonZeroU8, NonZeroUsize},
+    str::FromStr,
+};
 
 use alloy_primitives::Address;
 use alloy_transport_http::reqwest::Url;
-use anyhow::Result;
+use anyhow::{bail, Result};
 use op_succinct_host_utils::network::parse_fulfillment_strategy;
 use serde::{Deserialize, Serialize};
 use sp1_sdk::{network::FulfillmentStrategy, SP1ProofMode};
@@ -79,6 +83,15 @@ pub struct ProposerConfig {
 
     /// The gas limit to use for range proofs.
     pub range_gas_limit: u64,
+
+    /// The number of segments to split the range into (1-16).
+    pub range_split_count: RangeSplitCount,
+
+    /// The maximum number of concurrent range proof tasks. (default: 1)
+    ///
+    /// Increasing this feeds more work into the prover and host in parallel; tune carefully based
+    /// on observed latency, and system resources before deviating from default.
+    pub max_concurrent_range_proofs: NonZeroUsize,
 
     /// The cycle limit to use for aggregation proofs.
     pub agg_cycle_limit: u64,
@@ -168,6 +181,10 @@ impl ProposerConfig {
             range_gas_limit: env::var("RANGE_GAS_LIMIT")
                 .unwrap_or("1000000000000".to_string()) // 1 trillion
                 .parse()?,
+            range_split_count: env::var("RANGE_SPLIT_COUNT").unwrap_or("1".to_string()).parse()?,
+            max_concurrent_range_proofs: env::var("MAX_CONCURRENT_RANGE_PROOFS")
+                .unwrap_or("1".to_string())
+                .parse()?,
             agg_cycle_limit: env::var("AGG_CYCLE_LIMIT")
                 .unwrap_or("1000000000000".to_string()) // 1 trillion
                 .parse()?,
@@ -252,4 +269,206 @@ pub struct FaultDisputeGameConfig {
     pub starting_root: String,
     pub use_sp1_mock_verifier: bool,
     pub verifier_address: String,
+}
+
+/// How many chunks the range proof input is partitioned into (1-16 inclusive).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct RangeSplitCount(NonZeroU8);
+
+impl RangeSplitCount {
+    pub const MAX: u8 = 16;
+
+    /// Create a new `RangeSplitCount`.
+    pub fn new(count: u8) -> Result<Self> {
+        if count == 0 || count > Self::MAX {
+            bail!("range splits must be between 1 and 16, got {count}");
+        }
+
+        let count = NonZeroU8::new(count)
+            .ok_or_else(|| anyhow::anyhow!("range splits must be non zero"))?;
+
+        Ok(Self(count))
+    }
+
+    /// Returns a `RangeSplitCount` of one.
+    pub fn one() -> Self {
+        Self(NonZeroU8::new(1).expect("1 is non-zero"))
+    }
+
+    /// Convert to `usize`.
+    pub fn to_usize(self) -> usize {
+        self.0.get() as usize
+    }
+
+    /// Split `[start, end)` into up to `count` contiguous, non-empty subranges.
+    ///
+    /// Behavior:
+    /// - Errors if `start > end` or the range is empty.
+    /// - Caps the number of produced segments to the number of blocks in the range.
+    /// - Uses ceil division to keep segments as even as possible; the final segment takes any
+    ///   remainder.
+    /// - Always returns ranges that exactly cover `[start, end)` with no gaps or overlaps.
+    ///
+    /// NOTE: Ceiling division may yield fewer segments than requested when step sizes exhaust the
+    /// range early. Example: 9 blocks ÷ 4 → step=3 → 3 segments: [0,3), [3,6), [6,9).
+    pub fn split(&self, start: u64, end: u64) -> Result<Vec<(u64, u64)>> {
+        let total = end.checked_sub(start).ok_or_else(|| {
+            anyhow::anyhow!("end block {end} is not greater than start block {start}")
+        })?;
+        if total == 0 {
+            bail!("start block equals end block ({start}); nothing to prove");
+        }
+
+        let splits = self.to_usize();
+
+        if splits == 1 {
+            return Ok(vec![(start, end)]);
+        }
+
+        // Never split into more parts than there are blocks.
+        let segments = splits.min(total as usize);
+        let mut ranges = Vec::with_capacity(segments);
+
+        let step = total.div_ceil(segments as u64);
+
+        let mut cur = start;
+        for _ in 0..segments {
+            if cur >= end {
+                break;
+            }
+            let next = cur.saturating_add(step).min(end);
+            ranges.push((cur, next));
+            cur = next;
+        }
+
+        Ok(ranges)
+    }
+}
+
+impl TryFrom<u64> for RangeSplitCount {
+    type Error = anyhow::Error;
+
+    fn try_from(value: u64) -> Result<Self> {
+        let count: u8 = value
+            .try_into()
+            .map_err(|_| anyhow::anyhow!("range splits must be between 1 and 16, got {value}"))?;
+        Self::new(count)
+    }
+}
+
+impl FromStr for RangeSplitCount {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        let value: u64 = s.parse()?;
+        Self::try_from(value)
+    }
+}
+
+#[cfg(test)]
+mod split_range_tests {
+    use crate::config::RangeSplitCount;
+    use rstest::rstest;
+
+    fn range_split_count(count: u8) -> RangeSplitCount {
+        RangeSplitCount::new(count).expect("valid range split count")
+    }
+
+    /// Assert that ranges are non-empty, contiguous, and exactly cover [start, end).
+    fn assert_contiguous_cover(ranges: &[(u64, u64)], start: u64, end: u64) {
+        assert!(!ranges.is_empty(), "expected at least one range");
+        assert_eq!(ranges.first().unwrap().0, start, "first range should start at {start}");
+        assert_eq!(ranges.last().unwrap().1, end, "last range should end at {end}");
+        for window in ranges.windows(2) {
+            let a = window[0];
+            let b = window[1];
+            assert!(a.0 < a.1, "range must be non-empty: {}-{}", a.0, a.1);
+            assert_eq!(a.1, b.0, "ranges must be contiguous: {} != {}", a.1, b.0);
+            assert!(b.0 < b.1, "range must be non-empty: {}-{}", b.0, b.1);
+        }
+    }
+
+    #[rstest]
+    #[case::single_split(range_split_count(1), 10, 20, &[(10, 20)])]
+    #[case::single_block(range_split_count(2), 0, 1, &[(0, 1)])]
+    #[case::no_empty_tail(range_split_count(4), 0, 5, &[(0, 2), (2, 4), (4, 5)])]
+    #[case::offset_uneven(range_split_count(4), 5, 14, &[(5, 8), (8, 11), (11, 14)])]
+    #[case::even_split(range_split_count(4), 0, 10, &[(0, 3), (3, 6), (6, 9), (9, 10)])]
+    #[case::large_splits_small_range(range_split_count(15), 0, 1, &[(0, 1)])]
+    #[case::max_splits_exact(
+        range_split_count(RangeSplitCount::MAX),
+        0,
+        16,
+        &[
+            (0, 1),
+            (1, 2),
+            (2, 3),
+            (3, 4),
+            (4, 5),
+            (5, 6),
+            (6, 7),
+            (7, 8),
+            (8, 9),
+            (9, 10),
+            (10, 11),
+            (11, 12),
+            (12, 13),
+            (13, 14),
+            (14, 15),
+            (15, 16)
+        ]
+    )]
+    #[case::max_splits_caps(range_split_count(RangeSplitCount::MAX), 0, 3, &[(0, 1), (1, 2), (2, 3)])]
+    #[case::stop_when_done(
+        RangeSplitCount::new(15).unwrap(),
+        0,
+        16,
+        &[(0, 2), (2, 4), (4, 6), (6, 8), (8, 10), (10, 12), (12, 14), (14, 16)]
+    )]
+    fn test_splits_expected_paths(
+        #[case] splits: RangeSplitCount,
+        #[case] start: u64,
+        #[case] end: u64,
+        #[case] expected: &[(u64, u64)],
+    ) {
+        let ranges = splits.split(start, end).expect("split should succeed");
+        assert_eq!(ranges, expected);
+        assert_contiguous_cover(&ranges, start, end);
+    }
+
+    #[test]
+    fn test_splits_extreme() {
+        let start = u64::MAX - 100;
+        let end = u64::MAX;
+        let ranges =
+            RangeSplitCount::new(15).unwrap().split(start, end).expect("split should succeed");
+        assert_contiguous_cover(&ranges, start, end);
+    }
+
+    #[test]
+    fn test_errors_on_reversed_bounds() {
+        let err = RangeSplitCount::new(2).unwrap().split(8, 3).unwrap_err();
+        assert!(
+            err.to_string().contains("not greater than start block"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_errors_on_empty_range() {
+        let err = RangeSplitCount::new(2).unwrap().split(5, 5).unwrap_err();
+        assert!(err.to_string().contains("equals end block"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn test_rejects_zero() {
+        let err = RangeSplitCount::new(0).unwrap_err();
+        assert!(err.to_string().contains("between 1 and 16"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn test_rejects_above_max_from_str() {
+        let err = "17".parse::<RangeSplitCount>().unwrap_err();
+        assert!(err.to_string().contains("between 1 and 16"), "unexpected error: {err}");
+    }
 }

--- a/fault-proof/src/proposer.rs
+++ b/fault-proof/src/proposer.rs
@@ -1537,69 +1537,6 @@ where
     }
 }
 
-/// Result of fetching a game from the factory.
-///
-/// Games can either be added to the cache or dropped based on validation criteria.
-pub enum GameFetchResult {
-    /// Game was successfully validated and added to cache
-    ValidGame { game_address: Address, deadline: u64 },
-    /// Game type is unsupported
-    UnsupportedType { game_address: Address },
-    /// Game is invalid
-    InvalidGame { index: U256 },
-    /// Game was already present in the cache
-    AlreadyExists,
-}
-
-/// Cursor that tracks dispute-game indices, representing the current position in the ordered
-/// factory sequence.
-///
-/// Wraps `Option<U256>`:
-/// - `Some(i)`: concrete position within the factory's ordered game sequence.
-/// - `None`: sentinel meaning "no position" (before first game / past zero / uninitialized).
-#[derive(Default, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Cursor {
-    index: Option<U256>,
-}
-
-impl Cursor {
-    /// Create a cursor with no index.
-    pub fn none() -> Self {
-        Cursor { index: None }
-    }
-
-    /// Get the current index of the cursor.
-    pub fn index(&self) -> Option<U256> {
-        self.index
-    }
-
-    /// Step the cursor back by one. If the cursor is at zero, it becomes `None`.
-    pub fn step_back(&mut self) {
-        if let Some(idx) = self.index {
-            if idx > U256::ZERO {
-                self.index = Some(idx.saturating_sub(U256::ONE));
-            } else {
-                self.index = None;
-            }
-        }
-    }
-}
-
-impl std::fmt::Display for Cursor {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match &self.index {
-            Some(idx) => write!(f, "{idx}"),
-            None => write!(f, "None"),
-        }
-    }
-}
-
-impl From<U256> for Cursor {
-    fn from(idx: U256) -> Self {
-        Self { index: Some(idx) }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use crate::config::RangeSplitCount;

--- a/fault-proof/src/proposer.rs
+++ b/fault-proof/src/proposer.rs
@@ -672,8 +672,7 @@ where
             self.prover
                 .network_prover
                 .prove(&self.prover.agg_pk, sp1_stdin)
-                .plonk() // Is this safe to use the agg mode, previously it was
-                // hardcoded to plonk()
+                .mode(self.config.agg_proof_mode)
                 .strategy(self.config.agg_proof_strategy)
                 .timeout(Duration::from_secs(self.config.timeout))
                 .min_auction_period(self.config.min_auction_period)

--- a/fault-proof/src/proposer.rs
+++ b/fault-proof/src/proposer.rs
@@ -8,10 +8,11 @@ use std::{
 };
 
 use alloy_eips::BlockNumberOrTag;
-use alloy_primitives::{Address, TxHash, U256};
-use alloy_provider::{Provider, ProviderBuilder};
+use alloy_primitives::{Address, TxHash, B256, U256};
+use alloy_provider::{Provider, ProviderBuilder, RootProvider};
 use alloy_sol_types::{SolEvent, SolValue};
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
+use futures::stream::{self, StreamExt, TryStreamExt};
 use op_succinct_client_utils::boot::BootInfoStruct;
 use op_succinct_elfs::AGGREGATION_ELF;
 use op_succinct_host_utils::{
@@ -26,7 +27,7 @@ use op_succinct_proof_utils::get_range_elf_embedded;
 use op_succinct_signer_utils::SignerLock;
 use sp1_sdk::{
     NetworkProver, Prover, ProverClient, SP1ProofMode, SP1ProofWithPublicValues, SP1ProvingKey,
-    SP1VerifyingKey, SP1_CIRCUIT_VERSION,
+    SP1Stdin, SP1VerifyingKey, SP1_CIRCUIT_VERSION,
 };
 use tokio::{sync::Mutex, time};
 
@@ -34,7 +35,9 @@ use crate::{
     config::ProposerConfig,
     contract::{
         DisputeGameFactory::{DisputeGameCreated, DisputeGameFactoryInstance},
-        GameStatus, OPSuccinctFaultDisputeGame, ProposalStatus,
+        GameStatus,
+        OPSuccinctFaultDisputeGame::{self, OPSuccinctFaultDisputeGameInstance},
+        ProposalStatus,
     },
     is_parent_resolved,
     prometheus::ProposerGauge,
@@ -448,7 +451,12 @@ where
     /// - `u64`: Total instruction cycles used in the proof generation
     /// - `u64`: Total SP1 gas consumed in the proof generation
     #[tracing::instrument(name = "[[Proving]]", skip(self), fields(game_address = ?game_address))]
-    pub async fn prove_game(&self, game_address: Address) -> Result<(TxHash, u64, u64)> {
+    pub async fn prove_game(
+        &self,
+        game_address: Address,
+        start_block: u64,
+        end_block: u64,
+    ) -> Result<(TxHash, u64, u64)> {
         tracing::info!("Attempting to prove game {:?}", game_address);
 
         let fetcher = match OPSuccinctDataFetcher::new_with_rollup_config().await {
@@ -462,16 +470,107 @@ where
         let game = OPSuccinctFaultDisputeGame::new(game_address, self.l1_provider.clone());
         let l1_head_hash = game.l1Head().call().await?.0;
         tracing::debug!("L1 head hash: {:?}", hex::encode(l1_head_hash));
-        let l2_block_number = game.l2BlockNumber().call().await?;
 
+        let ranges = self
+            .config
+            .range_split_count
+            .split(start_block, end_block)
+            .context("failed to split range for proving")?;
+        let num_ranges = ranges.len();
+        tracing::info!("Proving over {num_ranges} ranges");
+
+        let tasks = ranges.into_iter().enumerate().map(|(idx, (start, end))| {
+            let this = self.clone();
+            async move {
+                tracing::info!("Generating Range Proof for blocks {start} to {end}");
+                let sp1_stdin = this.range_proof_stdin(start, end, l1_head_hash.into()).await?;
+                let (range_proof, inst_cycles, sp1_gas) =
+                    this.range_proof_request(&sp1_stdin).await?;
+                Ok::<_, anyhow::Error>((idx, range_proof, inst_cycles, sp1_gas))
+            }
+        });
+
+        let max_concurrent = self.config.max_concurrent_range_proofs.get().min(num_ranges);
+        let prove_stream = stream::iter(tasks);
+        let results: Vec<(usize, SP1ProofWithPublicValues, u64, u64)> =
+            prove_stream.buffer_unordered(max_concurrent).try_collect().await?;
+
+        let mut proofs = vec![None; num_ranges];
+        let mut boot_infos = vec![None; num_ranges];
+        let mut total_instruction_cycles: u64 = 0;
+        let mut total_sp1_gas: u64 = 0;
+
+        for (idx, range_proof, inst_cycles, sp1_gas) in results {
+            let proof = range_proof.proof.clone();
+            let mut public_values = range_proof.public_values.clone();
+            let boot_info: BootInfoStruct = public_values.read();
+
+            proofs[idx] = Some(proof);
+            boot_infos[idx] = Some(boot_info);
+            total_instruction_cycles = total_instruction_cycles
+                .checked_add(inst_cycles)
+                .ok_or_else(|| anyhow::anyhow!("Instruction cycles overflow"))?;
+            total_sp1_gas = total_sp1_gas
+                .checked_add(sp1_gas)
+                .ok_or_else(|| anyhow::anyhow!("SP1 gas overflow"))?;
+        }
+
+        let proofs = proofs
+            .into_iter()
+            .enumerate()
+            .map(|(idx, proof)| {
+                proof.ok_or_else(|| anyhow::anyhow!("missing proof for range index {idx}"))
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        let boot_infos = boot_infos
+            .into_iter()
+            .enumerate()
+            .map(|(idx, boot)| {
+                boot.ok_or_else(|| anyhow::anyhow!("missing boot info for range index {idx}"))
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        let latest_l1_head = boot_infos.last().context("No boot infos generated")?.l1Head;
+
+        let headers = match fetcher.get_header_preimages(&boot_infos, latest_l1_head).await {
+            Ok(headers) => headers,
+            Err(e) => {
+                tracing::error!("Failed to get header preimages: {e}");
+                bail!("Failed to get header preimages: {e}");
+            }
+        };
+
+        tracing::info!("Preparing Stdin for Agg Proof");
+        let sp1_stdin = match get_agg_proof_stdin(
+            proofs,
+            boot_infos,
+            headers,
+            &self.prover.range_vk,
+            latest_l1_head,
+            self.signer.address(),
+        ) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::error!("Failed to get agg proof stdin: {e}");
+                bail!("Failed to get agg proof stdin: {e}");
+            }
+        };
+
+        let tx_hash = self.agg_proof_request(&game, &sp1_stdin).await?;
+
+        Ok((tx_hash, total_instruction_cycles, total_sp1_gas))
+    }
+
+    async fn range_proof_stdin(
+        &self,
+        start_block: u64,
+        end_block: u64,
+        l1_head_hash: B256,
+    ) -> Result<SP1Stdin> {
         let host_args = self
             .host
-            .fetch(
-                l2_block_number.to::<u64>() - self.config.proposal_interval_in_blocks,
-                l2_block_number.to::<u64>(),
-                Some(l1_head_hash.into()),
-                self.config.safe_db_fallback,
-            )
+            .fetch(start_block, end_block, Some(l1_head_hash), self.config.safe_db_fallback)
             .await
             .context("Failed to get host CLI args")?;
 
@@ -485,13 +584,19 @@ where
             }
         };
 
-        tracing::info!("Generating Range Proof");
-        let (range_proof, total_instruction_cycles, total_sp1_gas) = if self.config.mock_mode {
+        Ok(sp1_stdin)
+    }
+
+    async fn range_proof_request(
+        &self,
+        sp1_stdin: &SP1Stdin,
+    ) -> Result<(SP1ProofWithPublicValues, u64, u64)> {
+        if self.config.mock_mode {
             tracing::info!("Using mock mode for range proof generation");
             let (public_values, report) = self
                 .prover
                 .network_prover
-                .execute(get_range_elf_embedded(), &sp1_stdin)
+                .execute(get_range_elf_embedded(), sp1_stdin)
                 .calculate_gas(true)
                 .deferred_proof_verification(false)
                 .run()?;
@@ -518,13 +623,13 @@ where
                 SP1_CIRCUIT_VERSION,
             );
 
-            (proof, total_instruction_cycles, total_sp1_gas)
+            Ok((proof, total_instruction_cycles, total_sp1_gas))
         } else {
             // In network mode, we don't have access to execution stats
             let proof = self
                 .prover
                 .network_prover
-                .prove(&self.prover.range_pk, &sp1_stdin)
+                .prove(&self.prover.range_pk, sp1_stdin)
                 .compressed()
                 .skip_simulation(true)
                 .strategy(self.config.range_proof_strategy)
@@ -537,47 +642,22 @@ where
                 .run_async()
                 .await?;
 
-            (proof, 0, 0)
-        };
+            Ok((proof, 0, 0))
+        }
+    }
 
-        tracing::info!("Preparing Stdin for Agg Proof");
-        let proof = range_proof.proof.clone();
-        let mut public_values = range_proof.public_values.clone();
-        let boot_info: BootInfoStruct = public_values.read();
-
-        let headers = match fetcher
-            .get_header_preimages(&vec![boot_info.clone()], boot_info.clone().l1Head)
-            .await
-        {
-            Ok(headers) => headers,
-            Err(e) => {
-                tracing::error!("Failed to get header preimages: {}", e);
-                return Err(anyhow::anyhow!("Failed to get header preimages: {}", e));
-            }
-        };
-
-        let sp1_stdin = match get_agg_proof_stdin(
-            vec![proof],
-            vec![boot_info.clone()],
-            headers,
-            &self.prover.range_vk,
-            boot_info.l1Head,
-            self.signer.address(),
-        ) {
-            Ok(s) => s,
-            Err(e) => {
-                tracing::error!("Failed to get agg proof stdin: {}", e);
-                return Err(anyhow::anyhow!("Failed to get agg proof stdin: {}", e));
-            }
-        };
-
+    async fn agg_proof_request(
+        &self,
+        game: &OPSuccinctFaultDisputeGameInstance<RootProvider>,
+        sp1_stdin: &SP1Stdin,
+    ) -> Result<TxHash> {
         tracing::info!("Generating Agg Proof");
         let agg_proof = if self.config.mock_mode {
             tracing::info!("Using mock mode for aggregation proof generation");
             let (public_values, _) = self
                 .prover
                 .network_prover
-                .execute(AGGREGATION_ELF, &sp1_stdin)
+                .execute(AGGREGATION_ELF, sp1_stdin)
                 .deferred_proof_verification(false)
                 .run()?;
 
@@ -591,8 +671,9 @@ where
         } else {
             self.prover
                 .network_prover
-                .prove(&self.prover.agg_pk, &sp1_stdin)
-                .plonk()
+                .prove(&self.prover.agg_pk, sp1_stdin)
+                .plonk() // Is this safe to use the agg mode, previously it was
+                // hardcoded to plonk()
                 .strategy(self.config.agg_proof_strategy)
                 .timeout(Duration::from_secs(self.config.timeout))
                 .min_auction_period(self.config.min_auction_period)
@@ -611,7 +692,7 @@ where
             .send_transaction_request(self.config.l1_rpc.clone(), transaction_request)
             .await?;
 
-        Ok((receipt.transaction_hash, total_instruction_cycles, total_sp1_gas))
+        Ok(receipt.transaction_hash)
     }
 
     /// Creates a new game with the given parameters.
@@ -1380,7 +1461,7 @@ where
                 rt.block_on(async move {
                     let start_time = std::time::Instant::now();
                     let (tx_hash, total_instruction_cycles, total_sp1_gas) =
-                        proposer.prove_game(game_address).await?;
+                        proposer.prove_game(game_address, start_block, end_block).await?;
 
                     // Record successful proving
                     ProposerGauge::GamesProven.increment(1.0);
@@ -1403,7 +1484,7 @@ where
             tokio::spawn(async move {
                 let start_time = std::time::Instant::now();
                 let (tx_hash, total_instruction_cycles, total_sp1_gas) =
-                    proposer.prove_game(game_address).await?;
+                    proposer.prove_game(game_address, start_block, end_block).await?;
 
                 // Record successful proving
                 ProposerGauge::GamesProven.increment(1.0);
@@ -1453,5 +1534,138 @@ where
         self.tasks.lock().await.insert(task_id, (handle, task_info));
         tracing::info!("Spawned bond claim task {}", task_id);
         Ok(())
+    }
+}
+
+/// Result of fetching a game from the factory.
+///
+/// Games can either be added to the cache or dropped based on validation criteria.
+pub enum GameFetchResult {
+    /// Game was successfully validated and added to cache
+    ValidGame { game_address: Address, deadline: u64 },
+    /// Game type is unsupported
+    UnsupportedType { game_address: Address },
+    /// Game is invalid
+    InvalidGame { index: U256 },
+    /// Game was already present in the cache
+    AlreadyExists,
+}
+
+/// Cursor that tracks dispute-game indices, representing the current position in the ordered
+/// factory sequence.
+///
+/// Wraps `Option<U256>`:
+/// - `Some(i)`: concrete position within the factory's ordered game sequence.
+/// - `None`: sentinel meaning "no position" (before first game / past zero / uninitialized).
+#[derive(Default, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Cursor {
+    index: Option<U256>,
+}
+
+impl Cursor {
+    /// Create a cursor with no index.
+    pub fn none() -> Self {
+        Cursor { index: None }
+    }
+
+    /// Get the current index of the cursor.
+    pub fn index(&self) -> Option<U256> {
+        self.index
+    }
+
+    /// Step the cursor back by one. If the cursor is at zero, it becomes `None`.
+    pub fn step_back(&mut self) {
+        if let Some(idx) = self.index {
+            if idx > U256::ZERO {
+                self.index = Some(idx.saturating_sub(U256::ONE));
+            } else {
+                self.index = None;
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for Cursor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.index {
+            Some(idx) => write!(f, "{idx}"),
+            None => write!(f, "None"),
+        }
+    }
+}
+
+impl From<U256> for Cursor {
+    fn from(idx: U256) -> Self {
+        Self { index: Some(idx) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::config::RangeSplitCount;
+    use anyhow::{bail, Result};
+    use futures::stream::{self, StreamExt, TryStreamExt};
+    use rstest::rstest;
+    use std::time::Duration;
+
+    async fn mock_prove(
+        idx: usize,
+        range: (u64, u64),
+        fail: bool,
+        delay: Duration,
+    ) -> Result<usize> {
+        tokio::time::sleep(delay).await;
+        if fail {
+            bail!("proof failed for range {}-{}", range.0, range.1);
+        }
+        Ok(idx)
+    }
+
+    async fn prove_ranges(
+        ranges: Vec<(u64, u64)>,
+        fail_idx: Option<usize>,
+        concurrency: usize,
+        delay: Duration,
+    ) -> Result<Vec<usize>> {
+        let tasks = ranges.into_iter().enumerate().map(|(idx, range)| {
+            let fail = fail_idx == Some(idx);
+            async move { mock_prove(idx, range, fail, delay).await }
+        });
+        stream::iter(tasks).buffer_unordered(concurrency).try_collect().await
+    }
+
+    #[rstest]
+    #[case::first(0, "0-25")]
+    #[case::middle(1, "25-50")]
+    #[case::last(3, "75-100")]
+    #[tokio::test]
+    async fn test_failure_aborts(#[case] fail_idx: usize, #[case] expected: &str) {
+        let ranges = RangeSplitCount::new(4).unwrap().split(0, 100).unwrap();
+        let err = prove_ranges(ranges, Some(fail_idx), 4, Duration::ZERO).await.unwrap_err();
+        assert!(err.to_string().contains(expected), "got: {err}");
+    }
+
+    #[rstest]
+    #[case::full(16)]
+    #[case::half(8)]
+    #[case::single(1)]
+    #[tokio::test]
+    async fn test_stress_varying_concurrency(#[case] concurrency: usize) {
+        let ranges = RangeSplitCount::new(16).unwrap().split(0, 1600).unwrap();
+        let results =
+            prove_ranges(ranges, None, concurrency, Duration::from_millis(5)).await.unwrap();
+
+        let mut indices: Vec<_> = results.clone();
+        indices.sort();
+        assert_eq!(indices, (0..16).collect::<Vec<_>>());
+    }
+
+    #[tokio::test]
+    async fn test_stress_repeated() {
+        for _ in 0..50 {
+            let ranges = RangeSplitCount::new(8).unwrap().split(0, 800).unwrap();
+            let results = prove_ranges(ranges, None, 4, Duration::from_micros(100)).await.unwrap();
+            assert_eq!(results.len(), 8);
+        }
     }
 }

--- a/fault-proof/tests/common/process.rs
+++ b/fault-proof/tests/common/process.rs
@@ -1,11 +1,13 @@
 //! Process management utilities for running proposer and challenger tasks.
-use std::sync::Arc;
+use std::{num::NonZero, sync::Arc};
 
 use alloy_primitives::Address;
 use alloy_provider::ProviderBuilder;
 use anyhow::Result;
 use fault_proof::{
-    challenger::OPSuccinctChallenger, config::ChallengerConfig, contract::DisputeGameFactory,
+    challenger::OPSuccinctChallenger,
+    config::{ChallengerConfig, RangeSplitCount},
+    contract::DisputeGameFactory,
     proposer::OPSuccinctProposer,
 };
 use op_succinct_host_utils::{
@@ -49,6 +51,8 @@ pub async fn init_proposer(
         timeout: 14400, // 4 hours
         range_cycle_limit: 1_000_000_000_000,
         range_gas_limit: 1_000_000_000_000,
+        range_split_count: RangeSplitCount::one(),
+        max_concurrent_range_proofs: NonZero::<usize>::MIN,
         agg_cycle_limit: 1_000_000_000_000,
         agg_gas_limit: 1_000_000_000_000,
         whitelist: None,


### PR DESCRIPTION
This cherry picks [9dbcbb9ce7d9e4aa0289427eb0923a7c89d011af](https://github.com/succinctlabs/op-succinct/commit/9dbcbb9ce7d9e4aa0289427eb0923a7c89d011af) from upstream to add proof splitting support to the proposer.

```
feat(fault-proof): support split range proving (#715)

* feat: can split proving range to 2,4,8,16
```
I've tested the general approach with a modified [multi in piersy/new-split-proof-ranges](https://github.com/celo-org/op-succinct/blob/piersy/new-split-proof-ranges/scripts/prove/bin/multi.rs) which succeeded for a 1800 block range on mainnet with 8 splits, so I believe this should work, but it's hard to test. So the next step would be to try running this on our chaos network with splitting and seeing how it performs.

In a separate PR I will introduce a script that we can use to test splitting, I've decided to not modify the multi because the changes are quite invasive and will complicate merging upstream, so instead I will create another script in a separate PR that we can use to test split proving over arbitrary ranges.