### PR TITLE
docker: Use smaller runtime image

### DIFF
--- a/fault-proof/Dockerfile.challenger.celo
+++ b/fault-proof/Dockerfile.challenger.celo
@@ -32,7 +32,6 @@ RUN cargo build --release --bin challenger --features eigenda
 FROM ubuntu:24.04
 
 WORKDIR /app
-COPY resources/ ./resources/
 
 # Install only necessary runtime dependencies
 RUN apt-get update && apt-get install -y \

--- a/fault-proof/Dockerfile.challenger.celo
+++ b/fault-proof/Dockerfile.challenger.celo
@@ -28,11 +28,17 @@ COPY . .
 # Build the binary
 RUN cargo build --release --bin challenger --features eigenda
 
-# Runtime stage
-FROM rust:1.89.0-trixie
+# Runtime stage (minimal image)
+FROM ubuntu:24.04
 
 WORKDIR /app
 COPY resources/ ./resources/
+
+# Install only necessary runtime dependencies
+RUN apt-get update && apt-get install -y \
+    curl \
+    libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 # Copy the built challenger binary
 COPY --from=builder /app/target/release/challenger /usr/local/bin/

--- a/fault-proof/Dockerfile.proposer.celo
+++ b/fault-proof/Dockerfile.proposer.celo
@@ -28,11 +28,17 @@ COPY . .
 # Build the binary
 RUN cargo build --release --bin proposer --features eigenda
 
-# Runtime stage
-FROM rust:1.89.0-trixie 
+# Runtime stage (minimal image)
+FROM ubuntu:24.04
 
 WORKDIR /app
 COPY resources/ ./resources/
+
+# Install only necessary runtime dependencies
+RUN apt-get update && apt-get install -y \
+    curl \
+    libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 # Copy the built proposer binary
 COPY --from=builder /app/target/release/proposer /usr/local/bin/


### PR DESCRIPTION
This reduces image size for the challenger from 1.7GB to 170MB.