### PR TITLE
chore(ci): disable trivy for push-container workflow

### DIFF
--- a/.github/workflows/push-container.yaml
+++ b/.github/workflows/push-container.yaml
@@ -52,7 +52,7 @@ jobs:
         && inputs.concurrency-group
         || format('{0}-{1}', github.workflow, (github.head_ref != '' && github.head_ref || github.ref)) }}
       cancel-in-progress: true
-    uses: celo-org/reusable-workflows/.github/workflows/docker-build.yaml@v3.1.0-rc.3
+    uses: celo-org/reusable-workflows/.github/workflows/docker-build.yaml@524a8f5bf429e518580da15d815cf571cdab2484
     with:
       runs-on: '["self-hosted", "org", "8-cpu"]'
       workload-id-provider: ${{ inputs.workload-id-provider }}


### PR DESCRIPTION
The container build workflow currently results in a lot of noise in PR comments, since every new push to a PR triggers multiple new scan results being appended to the PR.
Since we don't have a lot of control over upstream dependencies, the trivy scan results are not very actionable anyways.