### PR TITLE
Update push-container.yaml

### DIFF
--- a/.github/workflows/push-container.yaml
+++ b/.github/workflows/push-container.yaml
@@ -63,4 +63,4 @@ jobs:
       context: .
       file: ${{ inputs.file }}
       tags: ${{ needs.infer_image_metadata.outputs.tags }}
-      trivy-enabled: true
+      trivy-enabled: false


### PR DESCRIPTION
Disable trivy on container workflows due to noise from upstream repositories.