### PR TITLE
Enable remaining Github actions workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
     - name: Test
       run: just tests
       env:
-        L2_NODE_RPC: ${{ secrets.L2_NODE_RPC }} # TODO: set proper RPCs in secret to run the tests
+        L2_NODE_RPC: ${{ secrets.L2_NODE_RPC }}
         L1_RPC: ${{ secrets.L1_RPC }}
         L1_BEACON_RPC: ${{ secrets.L1_BEACON_RPC }}
         L2_RPC: ${{ secrets.L2_RPC }}

--- a/.github/workflows/cost-estimator-manual.yml
+++ b/.github/workflows/cost-estimator-manual.yml
@@ -1,34 +1,37 @@
-name: Cost Estimator (1000 blocks)
+name: Cost Estimator (1000 blocks) # Disabled because it requires more resource than current runner. Integration tests also include cost-estimator runs for 5 blocks.
 
 on:
   workflow_dispatch:
     inputs: {}
-  schedule:
-    - cron: '0 0 * * *' # Run the workflow every day at midnight UTC.
+#  schedule:
+#    - cron: '0 0 * * *' # Run the workflow every day at midnight UTC.
 
 jobs:
   daily-cost-estimator:
-    runs-on:
-      - runs-on
-      - cpu=32
-      - ram=128
-      - family=m7a+m7i-flex
-      - image=ubuntu22-full-x64
-      - run-id=${{ github.run_id }}
+    runs-on: [self-hosted, org, 8-cpu]
     steps:
       - uses: actions/checkout@v4
 
       - name: Setup CI
         uses: ./.github/actions/setup
 
+      - name: Install build deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential pkg-config libssl-dev
+          sudo apt-get install -y clang llvm-dev libclang-dev pkg-config
+
       - name: Run cost estimator
         run: |
-          RUST_LOG=info cargo run --bin cost-estimator --release -- --batch-size 30 --default-range 1000
+          RUST_LOG=info cargo run --bin cost-estimator --release --features eigenda -- --batch-size 30 --default-range 1000
         env:
           L2_NODE_RPC: ${{ secrets.L2_NODE_RPC }}
           L1_RPC: ${{ secrets.L1_RPC }}
           L1_BEACON_RPC: ${{ secrets.L1_BEACON_RPC }}
           L2_RPC: ${{ secrets.L2_RPC }}
+          EIGENDA_PROXY_ADDRESS: ${{ secrets.EIGENDA_PROXY_ADDRESS }}
+          SP1_PROVER: mock
+          OP_SUCCINCT_MOCK: true 
 
       - name: Upload execution reports
         uses: actions/upload-artifact@v4

--- a/.github/workflows/cycle-count-diff-eigenda.yml
+++ b/.github/workflows/cycle-count-diff-eigenda.yml
@@ -2,21 +2,13 @@ name: Cycle Count Diff (EigenDA)
 
 on:
   workflow_dispatch:
-#  pull_request:
-#    paths:
-#      - 'elf/eigenda-range-elf-embedded'
+  pull_request:
+    paths:
+      - 'elf/eigenda-range-elf-embedded'
 
 jobs:
   cycle-count-diff-eigenda:
-    runs-on:
-      - runs-on
-      - cpu=32
-      - ram=128
-      - family=m7a+m7i-flex
-      - image=ubuntu22-full-x64
-      - run-id=${{ github.run_id }}
-      - disk=large
-      - spot=false
+    runs-on: [self-hosted, org, 8-cpu]
 
     steps:
       - name: Checkout Repository (for local actions)
@@ -26,6 +18,12 @@ jobs:
         uses: ./.github/actions/setup
         with:
           submodules: recursive
+
+      - name: Install build deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential pkg-config libssl-dev
+          sudo apt-get install -y clang llvm-dev libclang-dev pkg-config
 
       - name: Install SP1 toolchain
         run: |
@@ -82,10 +80,10 @@ jobs:
           RUST_LOG=info NEW_BRANCH=true cargo test -p op-succinct-prove --features eigenda test_cycle_count_diff --release -- --exact --nocapture
         working-directory: ./new_code
         env:
-          L2_NODE_RPC: ${{ secrets.L2_EIGENDA_RPC }}
+          L2_NODE_RPC: ${{ secrets.L2_NODE_RPC }}
           L1_RPC: ${{ secrets.L1_RPC }}
           L1_BEACON_RPC: ${{ secrets.L1_BEACON_RPC }}
-          L2_RPC: ${{ secrets.L2_EIGENDA_RPC }}
+          L2_RPC: ${{ secrets.L2_RPC }}
           EIGENDA_PROXY_ADDRESS: ${{ secrets.EIGENDA_PROXY_ADDRESS }}
           OP_SUCCINCT_MOCK: true
 
@@ -99,10 +97,10 @@ jobs:
           RUST_LOG=info NEW_BRANCH=false cargo test -p op-succinct-prove --features eigenda test_cycle_count_diff --release -- --exact --nocapture
         working-directory: ./old_code
         env:
-          L2_NODE_RPC: ${{ secrets.L2_EIGENDA_RPC }}
+          L2_NODE_RPC: ${{ secrets.L2_NODE_RPC }}
           L1_RPC: ${{ secrets.L1_RPC }}
           L1_BEACON_RPC: ${{ secrets.L1_BEACON_RPC }}
-          L2_RPC: ${{ secrets.L2_EIGENDA_RPC }}
+          L2_RPC: ${{ secrets.L2_RPC }}
           EIGENDA_PROXY_ADDRESS: ${{ secrets.EIGENDA_PROXY_ADDRESS }}
           OP_SUCCINCT_MOCK: true
 

--- a/.github/workflows/foundry_test.yml
+++ b/.github/workflows/foundry_test.yml
@@ -54,4 +54,4 @@ jobs:
         id: test
         env:
           L2_NODE_RPC: ${{ secrets.L2_NODE_RPC }}
-          L1_RPC: ${{ secrets.L1_RPC }} # TODO: add Sepolia archive node L1 RPC to secret
+          L1_RPC: ${{ secrets.L1_RPC }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,10 +1,10 @@
 name: Integration Tests
 
 on:
-  # push:
-  #   branches: [ develop ]
-  # pull_request:
-  #   branches: [ develop ]
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
   workflow_dispatch:
 
 jobs:
@@ -25,3 +25,6 @@ jobs:
           L1_RPC: ${{ secrets.L1_RPC }}
           L1_BEACON_RPC: ${{ secrets.L1_BEACON_RPC }}
           L2_RPC: ${{ secrets.L2_RPC }}
+          EIGENDA_PROXY_ADDRESS: ${{ secrets.EIGENDA_PROXY_ADDRESS }}
+          SP1_PROVER: mock
+          OP_SUCCINCT_MOCK: true 


### PR DESCRIPTION
Enabled integration test which runs cost-estimator for recent 5 blocks on Celo Sepolia, and cycle count diff which compares the cycle count diff between prev code and current code in the PR and comments it like [this](https://github.com/celo-org/op-succinct/pull/83#issuecomment-3665379476).

I tried to enable daily cost-estimator that runs over 1,000 blocks every day, but it required more resource than our self-hosted runner. I think it's fine to disable it because integration test also includes cost-estimator run.

Closes https://github.com/celo-org/celo-blockchain-planning/issues/1145