### PR TITLE
Proposer: split proof blocking witness generation

### DIFF
--- a/fault-proof/src/proposer.rs
+++ b/fault-proof/src/proposer.rs
@@ -475,15 +475,16 @@ where
             .await
             .context("Failed to get host CLI args")?;
 
-        let witness_data = self.host.run(&host_args).await?;
-
-        let sp1_stdin = match self.host.witness_generator().get_sp1_stdin(witness_data) {
-            Ok(stdin) => stdin,
-            Err(e) => {
-                tracing::error!("Failed to get proof stdin: {}", e);
-                return Err(anyhow::anyhow!("Failed to get proof stdin: {}", e));
-            }
-        };
+        let host_clone = self.host.clone();
+        let sp1_stdin = tokio::task::spawn_blocking(move || {
+            let rt = tokio::runtime::Handle::current();
+            rt.block_on(async move {
+                let witness_data = host_clone.run(&host_args).await?;
+                host_clone.witness_generator().get_sp1_stdin(witness_data)
+            })
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("Witness generation task failed: {}", e))??;
 
         tracing::info!("Generating Range Proof");
         let (range_proof, total_instruction_cycles, total_sp1_gas) = if self.config.mock_mode {

--- a/fault-proof/src/proposer.rs
+++ b/fault-proof/src/proposer.rs
@@ -26,7 +26,7 @@ use op_succinct_proof_utils::get_range_elf_embedded;
 use op_succinct_signer_utils::SignerLock;
 use sp1_sdk::{
     NetworkProver, Prover, ProverClient, SP1ProofMode, SP1ProofWithPublicValues, SP1ProvingKey,
-    SP1VerifyingKey, SP1_CIRCUIT_VERSION,
+    SP1Stdin, SP1VerifyingKey, SP1_CIRCUIT_VERSION,
 };
 use tokio::{sync::Mutex, time};
 
@@ -479,8 +479,15 @@ where
         let sp1_stdin = tokio::task::spawn_blocking(move || {
             let rt = tokio::runtime::Handle::current();
             rt.block_on(async move {
-                let witness_data = host_clone.run(&host_args).await?;
-                host_clone.witness_generator().get_sp1_stdin(witness_data)
+                let witness_data = host_clone
+                    .run(&host_args)
+                    .await
+                    .inspect_err(|e| tracing::error!("Failed to generate witness: {e}"))?;
+                let sp1_stdin = host_clone
+                    .witness_generator()
+                    .get_sp1_stdin(witness_data)
+                    .inspect_err(|e| tracing::error!("Failed to get proof stdin: {e}"))?;
+                Ok::<SP1Stdin, anyhow::Error>(sp1_stdin)
             })
         })
         .await


### PR DESCRIPTION
This ensures that witness generation runs on the blocking
threadpool which prevents those tasks from starving the tokio
async runtime in the case that they did block on IO.

I don't actually know if there is blocking code being run during
witness generation, but if there is this change should prevent deadlocking.