### PR TITLE
Improve CI

### DIFF
--- a/.github/workflows/elf.yml
+++ b/.github/workflows/elf.yml
@@ -24,15 +24,17 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
           source $HOME/.cargo/env
           rustup show
 
       - name: Install SP1 toolchain
         run: |
+          source $HOME/.cargo/env
           curl -L https://sp1.succinct.xyz | bash
+          source ~/.bashrc
           ~/.sp1/bin/sp1up
           ~/.sp1/bin/cargo-prove prove --version
-          source ~/.bashrc
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Verify the OP Succinct binaries

--- a/.github/workflows/elf.yml
+++ b/.github/workflows/elf.yml
@@ -13,8 +13,8 @@ on:
 
 jobs:
   elf:
-    runs-on: ubuntu-latest
-
+    # runs-on: ubuntu-latest
+    runs-on: ["self-hosted", "org", "8-cpu"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/elf.yml
+++ b/.github/workflows/elf.yml
@@ -17,22 +17,16 @@ jobs:
     runs-on: ["self-hosted", "org", "8-cpu"]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.ref }}
-      - name: Free disk space
+
+      - name: Install Rust toolchain
         run: |
-          echo "Before cleanup:"
-          df -h /
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          source $HOME/.cargo/env
+          rustup show
 
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /usr/local/share/boost
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY" || true
-          docker system prune -af || true
-
-          echo "After cleanup:"
-          df -h /
       - name: Install SP1 toolchain
         run: |
           curl -L https://sp1.succinct.xyz | bash

--- a/.github/workflows/elf.yml
+++ b/.github/workflows/elf.yml
@@ -14,23 +14,12 @@ on:
 jobs:
   elf:
     # runs-on: ubuntu-latest
-    runs-on: ["self-hosted", "org", "8-cpu"]
+    runs-on: ["self-hosted", "org", "8-cpu-c3d"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.ref }}
-
-      - name: Cache Rust toolchain
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.rustup/toolchains
-            ~/.rustup/update-hashes
-            ~/.rustup/settings.toml
-          key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-rustup-
 
       - name: Install Rust toolchain
         run: |
@@ -39,27 +28,6 @@ jobs:
           source $HOME/.cargo/env
           rustup show
 
-      - name: Cache Cargo registry and git
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry/index
-            ~/.cargo/registry/cache
-            ~/.cargo/git/db
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
-
-      - name: Cache SP1 toolchain
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.sp1/bin
-            ~/.sp1/circuits
-          key: ${{ runner.os }}-sp1-v5.2.2
-          restore-keys: |
-            ${{ runner.os }}-sp1-
-
       - name: Install SP1 toolchain
         run: |
           source $HOME/.cargo/env
@@ -67,16 +35,11 @@ jobs:
           source ~/.bashrc
           ~/.sp1/bin/sp1up
           ~/.sp1/bin/cargo-prove prove --version
-
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3
-
       - name: Verify the OP Succinct binaries
         run: |
-          # Build the binaries with Docker BuildKit caching
-          # BuildKit will use inline cache and registry cache automatically
-          export DOCKER_BUILDKIT=1
-          
+          # Build the binaries
           cd programs/range/ethereum
           ~/.sp1/bin/cargo-prove prove build --elf-name range-elf-bump --docker --tag v5.2.2 --output-directory ../../../elf
           ~/.sp1/bin/cargo-prove prove build --elf-name range-elf-embedded --docker --tag v5.2.2 --output-directory ../../../elf --features embedded

--- a/.github/workflows/elf.yml
+++ b/.github/workflows/elf.yml
@@ -18,8 +18,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Install Rust toolchain
         run: |

--- a/.github/workflows/elf.yml
+++ b/.github/workflows/elf.yml
@@ -21,12 +21,44 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 
+      - name: Cache Rust toolchain
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.rustup/toolchains
+            ~/.rustup/update-hashes
+            ~/.rustup/settings.toml
+          key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-rustup-
+
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
           source $HOME/.cargo/env
           rustup show
+
+      - name: Cache Cargo registry and git
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Cache SP1 toolchain
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.sp1/bin
+            ~/.sp1/circuits
+          key: ${{ runner.os }}-sp1-v5.2.2
+          restore-keys: |
+            ${{ runner.os }}-sp1-
 
       - name: Install SP1 toolchain
         run: |
@@ -35,11 +67,16 @@ jobs:
           source ~/.bashrc
           ~/.sp1/bin/sp1up
           ~/.sp1/bin/cargo-prove prove --version
+
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3
+
       - name: Verify the OP Succinct binaries
         run: |
-          # Build the binaries
+          # Build the binaries with Docker BuildKit caching
+          # BuildKit will use inline cache and registry cache automatically
+          export DOCKER_BUILDKIT=1
+          
           cd programs/range/ethereum
           ~/.sp1/bin/cargo-prove prove build --elf-name range-elf-bump --docker --tag v5.2.2 --output-directory ../../../elf
           ~/.sp1/bin/cargo-prove prove build --elf-name range-elf-embedded --docker --tag v5.2.2 --output-directory ../../../elf --features embedded

--- a/.github/workflows/push-container-dev-non-essentials.yaml
+++ b/.github/workflows/push-container-dev-non-essentials.yaml
@@ -25,8 +25,8 @@ jobs:
           filters: |
             parallel_cost_estimator:
               - 'scripts/utils/Dockerfile.parallel-cost-estimator'
-              - 'scripts/utils/bin/parallel-cost-estimator.rs'
-              - 'scripts/utils/bin/cost-estimator.rs'
+              - 'scripts/utils/bin/parallel_cost_estimator.rs'
+              - 'scripts/utils/bin/cost_estimator.rs'
               - 'scripts/utils/src/**'
               - 'utils/**'
               - 'programs/**'

--- a/.github/workflows/push-container-dev-non-essentials.yaml
+++ b/.github/workflows/push-container-dev-non-essentials.yaml
@@ -10,8 +10,45 @@ on:
   workflow_dispatch:
 
 jobs:
+  detect_changes:
+    name: Detect file changes
+    runs-on: ubuntu-latest
+    # Always run on workflow_dispatch and push to develop, only check paths on pull_request
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || github.event_name == 'pull_request'
+    outputs:
+      parallel_cost_estimator: ${{ steps.filter.outputs.parallel_cost_estimator }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            parallel_cost_estimator:
+              - 'scripts/utils/Dockerfile.parallel-cost-estimator'
+              - 'scripts/utils/bin/parallel-cost-estimator.rs'
+              - 'scripts/utils/bin/cost-estimator.rs'
+              - 'scripts/utils/src/**'
+              - 'utils/**'
+              - 'programs/**'
+              - 'fault-proof/src/**'
+              - 'scripts/prove/**'
+              - 'validity/src/**'
+              - 'bindings/src/**'
+              - 'elf/**'
+              - 'resources/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - '**/Cargo.toml'
+              - 'rust-toolchain.toml'
+
   push_container_parallel-cost-estimator_dev:
     name: Build and push parallel-cost-estimator development image
+    needs: detect_changes
+    # Run if changes detected OR if triggered manually OR on push to develop
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'push' ||
+      needs.detect_changes.outputs.parallel_cost_estimator == 'true'
     uses: ./.github/workflows/push-container.yaml
     with:
       file: scripts/utils/Dockerfile.parallel-cost-estimator

--- a/.github/workflows/push-container-dev.yaml
+++ b/.github/workflows/push-container-dev.yaml
@@ -57,8 +57,8 @@ jobs:
               - 'rust-toolchain.toml'
             game_monitor:
               - 'scripts/utils/Dockerfile.game-monitor'
-              - 'scripts/utils/bin/game-monitor.rs'
-              - 'scripts/utils/bin/cost-estimator.rs'
+              - 'scripts/utils/bin/game_monitor.rs'
+              - 'scripts/utils/bin/cost_estimator.rs'
               - 'scripts/utils/src/**'
               - 'utils/**'
               - 'programs/**'

--- a/.github/workflows/push-container-dev.yaml
+++ b/.github/workflows/push-container-dev.yaml
@@ -10,8 +10,76 @@ on:
   workflow_dispatch:
 
 jobs:
+  detect_changes:
+    name: Detect file changes
+    runs-on: ubuntu-latest
+    # Always run on workflow_dispatch and push to develop, only check paths on pull_request
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || github.event_name == 'pull_request'
+    outputs:
+      proposer: ${{ steps.filter.outputs.proposer }}
+      challenger: ${{ steps.filter.outputs.challenger }}
+      game_monitor: ${{ steps.filter.outputs.game_monitor }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            proposer:
+              - 'fault-proof/Dockerfile.proposer.celo'
+              - 'fault-proof/bin/proposer.rs'
+              - 'fault-proof/src/**'
+              - 'utils/**'
+              - 'programs/**'
+              - 'scripts/prove/**'
+              - 'validity/src/**'
+              - 'bindings/src/**'
+              - 'elf/**'
+              - 'resources/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - '**/Cargo.toml'
+              - 'rust-toolchain.toml'
+            challenger:
+              - 'fault-proof/Dockerfile.challenger.celo'
+              - 'fault-proof/bin/challenger.rs'
+              - 'fault-proof/src/**'
+              - 'utils/**'
+              - 'programs/**'
+              - 'scripts/prove/**'
+              - 'validity/src/**'
+              - 'bindings/src/**'
+              - 'elf/**'
+              - 'resources/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - '**/Cargo.toml'
+              - 'rust-toolchain.toml'
+            game_monitor:
+              - 'scripts/utils/Dockerfile.game-monitor'
+              - 'scripts/utils/bin/game-monitor.rs'
+              - 'scripts/utils/bin/cost-estimator.rs'
+              - 'scripts/utils/src/**'
+              - 'utils/**'
+              - 'programs/**'
+              - 'fault-proof/src/**'
+              - 'scripts/prove/**'
+              - 'validity/src/**'
+              - 'bindings/src/**'
+              - 'elf/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - '**/Cargo.toml'
+              - 'rust-toolchain.toml'
+
   push_container_proposer_dev:
     name: Build and push proposer development image
+    needs: detect_changes
+    # Run if changes detected OR if triggered manually OR on push to develop
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'push' ||
+      needs.detect_changes.outputs.proposer == 'true'
     uses: ./.github/workflows/push-container.yaml
     with:
       file: fault-proof/Dockerfile.proposer.celo
@@ -19,8 +87,15 @@ jobs:
       service-account: op-succinct-gh-dev@devopsre.iam.gserviceaccount.com
       workload-id-provider: projects/1094498259535/locations/global/workloadIdentityPools/gh-op-succinct-dev/providers/github-by-repos
       concurrency-group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}-proposer-dev
+
   push_container_challenger_dev:
     name: Build and push challenger development image
+    needs: detect_changes
+    # Run if changes detected OR if triggered manually OR on push to develop
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'push' ||
+      needs.detect_changes.outputs.challenger == 'true'
     uses: ./.github/workflows/push-container.yaml
     with:
       file: fault-proof/Dockerfile.challenger.celo
@@ -28,8 +103,15 @@ jobs:
       service-account: op-succinct-gh-dev@devopsre.iam.gserviceaccount.com
       workload-id-provider: projects/1094498259535/locations/global/workloadIdentityPools/gh-op-succinct-dev/providers/github-by-repos
       concurrency-group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}-challenger-dev
+
   push_container_game_monitor_dev:
     name: Build and push game-monitor development image
+    needs: detect_changes
+    # Run if changes detected OR if triggered manually OR on push to develop
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'push' ||
+      needs.detect_changes.outputs.game_monitor == 'true'
     uses: ./.github/workflows/push-container.yaml
     with:
       file: scripts/utils/Dockerfile.game-monitor

--- a/.github/workflows/push-container.yaml
+++ b/.github/workflows/push-container.yaml
@@ -20,7 +20,7 @@ on:
 jobs:
   infer_image_metadata:
     name: Infer image tags from github ref type
-    runs-on: [self-hosted, org, 8-cpu]
+    runs-on: ubuntu-slim
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
       labels: ${{ steps.meta.outputs.labels }}
@@ -52,7 +52,7 @@ jobs:
         && inputs.concurrency-group
         || format('{0}-{1}', github.workflow, (github.head_ref != '' && github.head_ref || github.ref)) }}
       cancel-in-progress: true
-    uses: celo-org/reusable-workflows/.github/workflows/docker-build.yaml@v3.1.0-rc.3
+    uses: celo-org/reusable-workflows/.github/workflows/docker-build.yaml@v3.1.0-rc.4
     with:
       runs-on: '["self-hosted", "org", "8-cpu"]'
       workload-id-provider: ${{ inputs.workload-id-provider }}

--- a/.github/workflows/spell-checker.yml
+++ b/.github/workflows/spell-checker.yml
@@ -10,15 +10,15 @@ on:
 jobs:
   misspell:
     name: runner / misspell
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code.
-        uses: actions/checkout@v1
+        uses: actions/checkout@v6
       - name: misspell
         id: check_for_typos
         uses: reviewdog/action-misspell@v1
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ github.token }}
           path: "./book"
           locale: "US"
           exclude: |

--- a/.github/workflows/spell-checker.yml
+++ b/.github/workflows/spell-checker.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   misspell:
     name: runner / misspell
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Check out code.
         uses: actions/checkout@v1

--- a/.github/workflows/sqlx-check.yml
+++ b/.github/workflows/sqlx-check.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   sqlx-check:
     name: Verify SQLx queries
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v3
       

--- a/celo/.env.example
+++ b/celo/.env.example
@@ -2,4 +2,6 @@ PROPOSER_PK=
 L1_RPC_URL=
 L2_NODE_URL=
 DISPUTE_FACTORY_ADDRESS=
+# PROPOSAL_INTERVAL should be different from the L2 block number diff between challenged game and its parent to differentiate the game UUID
 PROPOSAL_INTERVAL=
+CHALLENGED_GAME_INDEX=

--- a/celo/.env.example
+++ b/celo/.env.example
@@ -2,6 +2,4 @@ PROPOSER_PK=
 L1_RPC_URL=
 L2_NODE_URL=
 DISPUTE_FACTORY_ADDRESS=
-# PROPOSAL_INTERVAL should be different from the L2 block number diff between challenged game and its parent to differentiate the game UUID
 PROPOSAL_INTERVAL=
-CHALLENGED_GAME_INDEX=

--- a/celo/create_first_42_game.sh
+++ b/celo/create_first_42_game.sh
@@ -1,18 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Usage: 
-# ./create_new_game_branch.sh .env.example
-#
-# Description:
-# This script creates a new game branch to recover from CHALLENGER_WINS game chain. It fetches the 
-# parent game information, calculates the target L2 block number based on the proposal interval,
-# retrieves the output root for that block, and creates a new game by calling the dispute factory's
-# create() function.
-#
-# This script is part of the Succinct Dispute Game Recovery runbook:
-# https://www.notion.so/clabsco/Succinct-Dispute-Game-Recovery-Handling-Proving-Failures-2c3ea6297b89801b87a7c47d97ba8a35?source=copy_link
-
 # Optional: load env vars from file passed as first argument
 if (( $# >= 1 )) && [[ -n "${1:-}" ]]; then
   ENV_FILE="$1"
@@ -33,7 +21,6 @@ required_vars=(
   L1_RPC_URL
   L2_NODE_URL
   DISPUTE_FACTORY_ADDRESS
-  CHALLENGED_GAME_INDEX
   PROPOSAL_INTERVAL
 )
 
@@ -49,7 +36,16 @@ init_bond_hex=$(cast call "$DISPUTE_FACTORY_ADDRESS" "initBonds(uint32)" 42 -r "
 init_bond=$(cast --to-dec "$init_bond_hex")
 echo "Init bond: $init_bond"
 
-parent_index=$(( CHALLENGED_GAME_INDEX - 1 ))
+echo "Fetching game count..."
+game_count_hex=$(cast call "$DISPUTE_FACTORY_ADDRESS" "gameCount()" -r "$L1_RPC_URL")
+game_count=$(cast --to-dec "$game_count_hex")
+
+if (( game_count <= 0 )); then
+  echo "Error: No existing games found (game_count=$game_count). Cannot derive parent index." >&2
+  exit 1
+fi
+
+parent_index=$(( game_count - 1 ))
 echo "Parent index: $parent_index"
 
 echo "Fetching parent game tuple (type,timestamp,address)..."
@@ -65,7 +61,14 @@ if [ $cast_exit_code -ne 0 ] || [ -z "$result" ]; then
 fi
 
 # Parse the result - it comes as multiple lines
+game_type=$(echo "$result" | head -n1)
 parent_address=$(echo "$result" | tail -n1)
+
+if [ $game_type -ne 1 ]; then
+    echo "Error: Parent game is not of type 1." >&2
+    exit 1
+fi
+
 echo "Parent game proxy address: $parent_address"
 
 echo "Fetching parent game's L2 block number..."

--- a/celo/create_new_game_branch.sh
+++ b/celo/create_new_game_branch.sh
@@ -1,6 +1,18 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Usage: 
+# ./create_new_game_branch.sh .env.example
+#
+# Description:
+# This script creates a new game branch to recover from CHALLENGER_WINS game chain. It fetches the 
+# parent game information, calculates the target L2 block number based on the proposal interval,
+# retrieves the output root for that block, and creates a new game by calling the dispute factory's
+# create() function.
+#
+# This script is part of the Succinct Dispute Game Recovery runbook:
+# https://www.notion.so/clabsco/Succinct-Dispute-Game-Recovery-Handling-Proving-Failures-2c3ea6297b89801b87a7c47d97ba8a35?source=copy_link
+
 # Optional: load env vars from file passed as first argument
 if (( $# >= 1 )) && [[ -n "${1:-}" ]]; then
   ENV_FILE="$1"
@@ -21,6 +33,7 @@ required_vars=(
   L1_RPC_URL
   L2_NODE_URL
   DISPUTE_FACTORY_ADDRESS
+  CHALLENGED_GAME_INDEX
   PROPOSAL_INTERVAL
 )
 
@@ -36,16 +49,7 @@ init_bond_hex=$(cast call "$DISPUTE_FACTORY_ADDRESS" "initBonds(uint32)" 42 -r "
 init_bond=$(cast --to-dec "$init_bond_hex")
 echo "Init bond: $init_bond"
 
-echo "Fetching game count..."
-game_count_hex=$(cast call "$DISPUTE_FACTORY_ADDRESS" "gameCount()" -r "$L1_RPC_URL")
-game_count=$(cast --to-dec "$game_count_hex")
-
-if (( game_count <= 0 )); then
-  echo "Error: No existing games found (game_count=$game_count). Cannot derive parent index." >&2
-  exit 1
-fi
-
-parent_index=$(( game_count - 1 ))
+parent_index=$(( CHALLENGED_GAME_INDEX - 1 ))
 echo "Parent index: $parent_index"
 
 echo "Fetching parent game tuple (type,timestamp,address)..."
@@ -61,14 +65,7 @@ if [ $cast_exit_code -ne 0 ] || [ -z "$result" ]; then
 fi
 
 # Parse the result - it comes as multiple lines
-game_type=$(echo "$result" | head -n1)
 parent_address=$(echo "$result" | tail -n1)
-
-if [ $game_type -ne 1 ]; then
-    echo "Error: Parent game is not of type 1." >&2
-    exit 1
-fi
-
 echo "Parent game proxy address: $parent_address"
 
 echo "Fetching parent game's L2 block number..."
@@ -117,3 +114,4 @@ tx_hash=$(cast send "$DISPUTE_FACTORY_ADDRESS" "create(uint32,bytes32,bytes)" 42
 echo "Transaction sent: $tx_hash"
 
 echo "Done."
+

--- a/fault-proof/Dockerfile.challenger.celo
+++ b/fault-proof/Dockerfile.challenger.celo
@@ -119,10 +119,18 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 RUN --mount=type=cache,target=/app/target \
     cp /app/target/release/challenger /app/challenger
 
-# Runtime stage
-FROM rust:1.89.0-trixie
+# Runtime stage (minimal image - only runtime dependencies)
+FROM debian:bookworm-slim
 
 WORKDIR /app
+
+# Install only necessary runtime dependencies
+# libssl3 is needed for reqwest-native-tls, ca-certificates for HTTPS
+RUN apt-get update && apt-get install -y \
+    libssl3 \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY resources/ ./resources/
 
 # Copy the built challenger binary (copied from cache mount to filesystem)

--- a/fault-proof/Dockerfile.challenger.celo
+++ b/fault-proof/Dockerfile.challenger.celo
@@ -92,8 +92,12 @@ RUN mkdir -p fault-proof/src fault-proof/bin && \
     echo "" > bindings/src/lib.rs
 
 # Download and compile dependencies (this layer will be cached if Cargo.toml/Cargo.lock don't change)
+# Use BuildKit cache mounts for faster Cargo operations
 # The || true allows this to fail gracefully since we have dummy source files
-RUN cargo build --release --bin challenger --features eigenda || true
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/app/target \
+    cargo build --release --bin challenger --features eigenda || true
 
 # Now copy the actual source code
 COPY fault-proof/src ./fault-proof/src
@@ -105,7 +109,11 @@ COPY validity/src ./validity/src
 COPY bindings/src ./bindings/src
 
 # Build the actual binary (only rebuilds if source changed)
-RUN cargo build --release --bin challenger --features eigenda
+# Use BuildKit cache mounts for faster builds
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/app/target \
+    cargo build --release --bin challenger --features eigenda
 
 # Runtime stage
 FROM rust:1.89.0-trixie

--- a/fault-proof/Dockerfile.challenger.celo
+++ b/fault-proof/Dockerfile.challenger.celo
@@ -123,7 +123,7 @@ RUN --mount=type=cache,target=/app/target \
     cp /app/target/release/challenger /app/challenger
 
 # Runtime stage (minimal image - only runtime dependencies)
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 WORKDIR /app
 

--- a/fault-proof/Dockerfile.challenger.celo
+++ b/fault-proof/Dockerfile.challenger.celo
@@ -23,9 +23,88 @@ RUN curl -L https://sp1.succinct.xyz | bash && \
 FROM base AS builder
 
 WORKDIR /app
-COPY . .
 
-# Build the binary
+# Copy workspace root Cargo files
+COPY Cargo.toml Cargo.lock ./
+
+# Copy all Cargo.toml files from workspace members
+# This allows Cargo to resolve dependencies without source
+COPY fault-proof/Cargo.toml ./fault-proof/
+COPY utils/client/Cargo.toml ./utils/client/
+COPY utils/host/Cargo.toml ./utils/host/
+COPY utils/build/Cargo.toml ./utils/build/
+COPY utils/celestia/client/Cargo.toml ./utils/celestia/client/
+COPY utils/celestia/host/Cargo.toml ./utils/celestia/host/
+COPY utils/eigenda/client/Cargo.toml ./utils/eigenda/client/
+COPY utils/eigenda/host/Cargo.toml ./utils/eigenda/host/
+COPY utils/proof/Cargo.toml ./utils/proof/
+COPY utils/signer/Cargo.toml ./utils/signer/
+COPY utils/ethereum/client/Cargo.toml ./utils/ethereum/client/
+COPY utils/ethereum/host/Cargo.toml ./utils/ethereum/host/
+COPY utils/elfs/Cargo.toml ./utils/elfs/
+COPY programs/range/ethereum/Cargo.toml ./programs/range/ethereum/
+COPY programs/range/celestia/Cargo.toml ./programs/range/celestia/
+COPY programs/range/eigenda/Cargo.toml ./programs/range/eigenda/
+COPY programs/range/utils/Cargo.toml ./programs/range/utils/
+COPY programs/aggregation/Cargo.toml ./programs/aggregation/
+COPY scripts/prove/Cargo.toml ./scripts/prove/
+COPY scripts/utils/Cargo.toml ./scripts/utils/
+COPY validity/Cargo.toml ./validity/
+COPY bindings/Cargo.toml ./bindings/
+
+# Create dummy source files to satisfy Cargo's dependency resolution
+# This allows us to download and compile dependencies without the actual source
+RUN mkdir -p fault-proof/src fault-proof/bin && \
+    mkdir -p utils/client/src utils/host/src utils/build/src && \
+    mkdir -p utils/celestia/client/src utils/celestia/host/src && \
+    mkdir -p utils/eigenda/client/src utils/eigenda/host/src && \
+    mkdir -p utils/proof/src utils/signer/src && \
+    mkdir -p utils/ethereum/client/src utils/ethereum/host/src && \
+    mkdir -p utils/elfs/src && \
+    mkdir -p programs/range/ethereum/src programs/range/celestia/src && \
+    mkdir -p programs/range/eigenda/src programs/range/utils/src && \
+    mkdir -p programs/aggregation/src && \
+    mkdir -p scripts/prove/src scripts/utils/src && \
+    mkdir -p validity/src bindings/src && \
+    echo "fn main() {}" > fault-proof/bin/proposer.rs && \
+    echo "fn main() {}" > fault-proof/bin/challenger.rs && \
+    echo "" > fault-proof/src/lib.rs && \
+    echo "" > utils/client/src/lib.rs && \
+    echo "" > utils/host/src/lib.rs && \
+    echo "" > utils/build/src/lib.rs && \
+    echo "" > utils/celestia/client/src/lib.rs && \
+    echo "" > utils/celestia/host/src/lib.rs && \
+    echo "" > utils/eigenda/client/src/lib.rs && \
+    echo "" > utils/eigenda/host/src/lib.rs && \
+    echo "" > utils/proof/src/lib.rs && \
+    echo "" > utils/signer/src/lib.rs && \
+    echo "" > utils/ethereum/client/src/lib.rs && \
+    echo "" > utils/ethereum/host/src/lib.rs && \
+    echo "" > utils/elfs/src/lib.rs && \
+    echo "" > programs/range/ethereum/src/lib.rs && \
+    echo "" > programs/range/celestia/src/lib.rs && \
+    echo "" > programs/range/eigenda/src/lib.rs && \
+    echo "" > programs/range/utils/src/lib.rs && \
+    echo "" > programs/aggregation/src/lib.rs && \
+    echo "" > scripts/prove/src/lib.rs && \
+    echo "" > scripts/utils/src/lib.rs && \
+    echo "" > validity/src/lib.rs && \
+    echo "" > bindings/src/lib.rs
+
+# Download and compile dependencies (this layer will be cached if Cargo.toml/Cargo.lock don't change)
+# The || true allows this to fail gracefully since we have dummy source files
+RUN cargo build --release --bin challenger --features eigenda || true
+
+# Now copy the actual source code
+COPY fault-proof/src ./fault-proof/src
+COPY fault-proof/bin ./fault-proof/bin
+COPY utils/ ./utils/
+COPY programs/ ./programs/
+COPY scripts/ ./scripts/
+COPY validity/src ./validity/src
+COPY bindings/src ./bindings/src
+
+# Build the actual binary (only rebuilds if source changed)
 RUN cargo build --release --bin challenger --features eigenda
 
 # Runtime stage

--- a/fault-proof/Dockerfile.challenger.celo
+++ b/fault-proof/Dockerfile.challenger.celo
@@ -115,14 +115,18 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/app/target \
     cargo build --release --bin challenger --features eigenda
 
+# Copy binary from cache mount to filesystem so it can be copied to runtime stage
+RUN --mount=type=cache,target=/app/target \
+    cp /app/target/release/challenger /app/challenger
+
 # Runtime stage
 FROM rust:1.89.0-trixie
 
 WORKDIR /app
 COPY resources/ ./resources/
 
-# Copy the built challenger binary
-COPY --from=builder /app/target/release/challenger /usr/local/bin/
+# Copy the built challenger binary (copied from cache mount to filesystem)
+COPY --from=builder /app/challenger /usr/local/bin/
 
 # Set the command
 CMD ["challenger"]

--- a/fault-proof/Dockerfile.challenger.celo
+++ b/fault-proof/Dockerfile.challenger.celo
@@ -52,6 +52,9 @@ COPY scripts/utils/Cargo.toml ./scripts/utils/
 COPY validity/Cargo.toml ./validity/
 COPY bindings/Cargo.toml ./bindings/
 
+# Copy elf binaries needed by utils/elfs at compile time (needed before building)
+COPY elf/ ./elf/
+
 # Create dummy source files to satisfy Cargo's dependency resolution
 # This allows us to download and compile dependencies without the actual source
 RUN mkdir -p fault-proof/src fault-proof/bin && \

--- a/fault-proof/Dockerfile.proposer.celo
+++ b/fault-proof/Dockerfile.proposer.celo
@@ -119,10 +119,18 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 RUN --mount=type=cache,target=/app/target \
     cp /app/target/release/proposer /app/proposer
 
-# Runtime stage
-FROM rust:1.89.0-trixie 
+# Runtime stage (minimal image - only runtime dependencies)
+FROM debian:bookworm-slim
 
 WORKDIR /app
+
+# Install only necessary runtime dependencies
+# libssl3 is needed for reqwest-native-tls, ca-certificates for HTTPS
+RUN apt-get update && apt-get install -y \
+    libssl3 \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY resources/ ./resources/
 
 # Copy the built proposer binary (copied from cache mount to filesystem)

--- a/fault-proof/Dockerfile.proposer.celo
+++ b/fault-proof/Dockerfile.proposer.celo
@@ -23,9 +23,88 @@ RUN curl -L https://sp1.succinct.xyz | bash && \
 FROM base AS builder
 
 WORKDIR /app
-COPY . .
 
-# Build the binary
+# Copy workspace root Cargo files
+COPY Cargo.toml Cargo.lock ./
+
+# Copy all Cargo.toml files from workspace members
+# This allows Cargo to resolve dependencies without source
+COPY fault-proof/Cargo.toml ./fault-proof/
+COPY utils/client/Cargo.toml ./utils/client/
+COPY utils/host/Cargo.toml ./utils/host/
+COPY utils/build/Cargo.toml ./utils/build/
+COPY utils/celestia/client/Cargo.toml ./utils/celestia/client/
+COPY utils/celestia/host/Cargo.toml ./utils/celestia/host/
+COPY utils/eigenda/client/Cargo.toml ./utils/eigenda/client/
+COPY utils/eigenda/host/Cargo.toml ./utils/eigenda/host/
+COPY utils/proof/Cargo.toml ./utils/proof/
+COPY utils/signer/Cargo.toml ./utils/signer/
+COPY utils/ethereum/client/Cargo.toml ./utils/ethereum/client/
+COPY utils/ethereum/host/Cargo.toml ./utils/ethereum/host/
+COPY utils/elfs/Cargo.toml ./utils/elfs/
+COPY programs/range/ethereum/Cargo.toml ./programs/range/ethereum/
+COPY programs/range/celestia/Cargo.toml ./programs/range/celestia/
+COPY programs/range/eigenda/Cargo.toml ./programs/range/eigenda/
+COPY programs/range/utils/Cargo.toml ./programs/range/utils/
+COPY programs/aggregation/Cargo.toml ./programs/aggregation/
+COPY scripts/prove/Cargo.toml ./scripts/prove/
+COPY scripts/utils/Cargo.toml ./scripts/utils/
+COPY validity/Cargo.toml ./validity/
+COPY bindings/Cargo.toml ./bindings/
+
+# Create dummy source files to satisfy Cargo's dependency resolution
+# This allows us to download and compile dependencies without the actual source
+RUN mkdir -p fault-proof/src fault-proof/bin && \
+    mkdir -p utils/client/src utils/host/src utils/build/src && \
+    mkdir -p utils/celestia/client/src utils/celestia/host/src && \
+    mkdir -p utils/eigenda/client/src utils/eigenda/host/src && \
+    mkdir -p utils/proof/src utils/signer/src && \
+    mkdir -p utils/ethereum/client/src utils/ethereum/host/src && \
+    mkdir -p utils/elfs/src && \
+    mkdir -p programs/range/ethereum/src programs/range/celestia/src && \
+    mkdir -p programs/range/eigenda/src programs/range/utils/src && \
+    mkdir -p programs/aggregation/src && \
+    mkdir -p scripts/prove/src scripts/utils/src && \
+    mkdir -p validity/src bindings/src && \
+    echo "fn main() {}" > fault-proof/bin/proposer.rs && \
+    echo "fn main() {}" > fault-proof/bin/challenger.rs && \
+    echo "" > fault-proof/src/lib.rs && \
+    echo "" > utils/client/src/lib.rs && \
+    echo "" > utils/host/src/lib.rs && \
+    echo "" > utils/build/src/lib.rs && \
+    echo "" > utils/celestia/client/src/lib.rs && \
+    echo "" > utils/celestia/host/src/lib.rs && \
+    echo "" > utils/eigenda/client/src/lib.rs && \
+    echo "" > utils/eigenda/host/src/lib.rs && \
+    echo "" > utils/proof/src/lib.rs && \
+    echo "" > utils/signer/src/lib.rs && \
+    echo "" > utils/ethereum/client/src/lib.rs && \
+    echo "" > utils/ethereum/host/src/lib.rs && \
+    echo "" > utils/elfs/src/lib.rs && \
+    echo "" > programs/range/ethereum/src/lib.rs && \
+    echo "" > programs/range/celestia/src/lib.rs && \
+    echo "" > programs/range/eigenda/src/lib.rs && \
+    echo "" > programs/range/utils/src/lib.rs && \
+    echo "" > programs/aggregation/src/lib.rs && \
+    echo "" > scripts/prove/src/lib.rs && \
+    echo "" > scripts/utils/src/lib.rs && \
+    echo "" > validity/src/lib.rs && \
+    echo "" > bindings/src/lib.rs
+
+# Download and compile dependencies (this layer will be cached if Cargo.toml/Cargo.lock don't change)
+# The || true allows this to fail gracefully since we have dummy source files
+RUN cargo build --release --bin proposer --features eigenda || true
+
+# Now copy the actual source code
+COPY fault-proof/src ./fault-proof/src
+COPY fault-proof/bin ./fault-proof/bin
+COPY utils/ ./utils/
+COPY programs/ ./programs/
+COPY scripts/ ./scripts/
+COPY validity/src ./validity/src
+COPY bindings/src ./bindings/src
+
+# Build the actual binary (only rebuilds if source changed)
 RUN cargo build --release --bin proposer --features eigenda
 
 # Runtime stage

--- a/fault-proof/Dockerfile.proposer.celo
+++ b/fault-proof/Dockerfile.proposer.celo
@@ -92,8 +92,12 @@ RUN mkdir -p fault-proof/src fault-proof/bin && \
     echo "" > bindings/src/lib.rs
 
 # Download and compile dependencies (this layer will be cached if Cargo.toml/Cargo.lock don't change)
+# Use BuildKit cache mounts for faster Cargo operations
 # The || true allows this to fail gracefully since we have dummy source files
-RUN cargo build --release --bin proposer --features eigenda || true
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/app/target \
+    cargo build --release --bin proposer --features eigenda || true
 
 # Now copy the actual source code
 COPY fault-proof/src ./fault-proof/src
@@ -105,7 +109,11 @@ COPY validity/src ./validity/src
 COPY bindings/src ./bindings/src
 
 # Build the actual binary (only rebuilds if source changed)
-RUN cargo build --release --bin proposer --features eigenda
+# Use BuildKit cache mounts for faster builds
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/app/target \
+    cargo build --release --bin proposer --features eigenda
 
 # Runtime stage
 FROM rust:1.89.0-trixie 

--- a/fault-proof/Dockerfile.proposer.celo
+++ b/fault-proof/Dockerfile.proposer.celo
@@ -123,7 +123,7 @@ RUN --mount=type=cache,target=/app/target \
     cp /app/target/release/proposer /app/proposer
 
 # Runtime stage (minimal image - only runtime dependencies)
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 WORKDIR /app
 

--- a/fault-proof/Dockerfile.proposer.celo
+++ b/fault-proof/Dockerfile.proposer.celo
@@ -115,14 +115,18 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/app/target \
     cargo build --release --bin proposer --features eigenda
 
+# Copy binary from cache mount to filesystem so it can be copied to runtime stage
+RUN --mount=type=cache,target=/app/target \
+    cp /app/target/release/proposer /app/proposer
+
 # Runtime stage
 FROM rust:1.89.0-trixie 
 
 WORKDIR /app
 COPY resources/ ./resources/
 
-# Copy the built proposer binary
-COPY --from=builder /app/target/release/proposer /usr/local/bin/
+# Copy the built proposer binary (copied from cache mount to filesystem)
+COPY --from=builder /app/proposer /usr/local/bin/
 
 # Set the command
 CMD ["proposer"]

--- a/fault-proof/Dockerfile.proposer.celo
+++ b/fault-proof/Dockerfile.proposer.celo
@@ -52,6 +52,9 @@ COPY scripts/utils/Cargo.toml ./scripts/utils/
 COPY validity/Cargo.toml ./validity/
 COPY bindings/Cargo.toml ./bindings/
 
+# Copy elf binaries needed by utils/elfs at compile time (needed before building)
+COPY elf/ ./elf/
+
 # Create dummy source files to satisfy Cargo's dependency resolution
 # This allows us to download and compile dependencies without the actual source
 RUN mkdir -p fault-proof/src fault-proof/bin && \

--- a/scripts/utils/Dockerfile.game-monitor
+++ b/scripts/utils/Dockerfile.game-monitor
@@ -66,65 +66,44 @@ COPY scripts/utils/Cargo.toml ./scripts/utils/
 COPY validity/Cargo.toml ./validity/
 COPY bindings/Cargo.toml ./bindings/
 
-# Create dummy source files to satisfy Cargo's dependency resolution
-# This allows us to download and compile dependencies without the actual source
-RUN mkdir -p fault-proof/src fault-proof/bin && \
-    mkdir -p utils/client/src utils/host/src utils/build/src && \
-    mkdir -p utils/celestia/client/src utils/celestia/host/src && \
-    mkdir -p utils/eigenda/client/src utils/eigenda/host/src && \
-    mkdir -p utils/proof/src utils/signer/src && \
-    mkdir -p utils/ethereum/client/src utils/ethereum/host/src && \
-    mkdir -p utils/elfs/src && \
-    mkdir -p programs/range/ethereum/src programs/range/celestia/src && \
-    mkdir -p programs/range/eigenda/src programs/range/utils/src && \
-    mkdir -p programs/aggregation/src && \
-    mkdir -p scripts/prove/src scripts/utils/src && \
+# Copy actual source code for library crates (needed for dependency compilation)
+# These are workspace dependencies that other crates import from
+COPY utils/ ./utils/
+COPY programs/ ./programs/
+COPY bindings/src ./bindings/src
+COPY validity/src ./validity/src
+COPY fault-proof/src ./fault-proof/src
+COPY scripts/utils/src ./scripts/utils/src
+COPY scripts/prove/src ./scripts/prove/src
+
+# Create dummy binary source files (binaries are what we're building, so we can cache their compilation)
+RUN mkdir -p fault-proof/bin && \
     mkdir -p scripts/utils/bin && \
-    mkdir -p validity/src bindings/src && \
     echo "fn main() {}" > fault-proof/bin/proposer.rs && \
     echo "fn main() {}" > fault-proof/bin/challenger.rs && \
     echo "fn main() {}" > scripts/utils/bin/cost-estimator.rs && \
-    echo "fn main() {}" > scripts/utils/bin/game-monitor.rs && \
-    echo "" > fault-proof/src/lib.rs && \
-    echo "" > utils/client/src/lib.rs && \
-    echo "" > utils/host/src/lib.rs && \
-    echo "" > utils/build/src/lib.rs && \
-    echo "" > utils/celestia/client/src/lib.rs && \
-    echo "" > utils/celestia/host/src/lib.rs && \
-    echo "" > utils/eigenda/client/src/lib.rs && \
-    echo "" > utils/eigenda/host/src/lib.rs && \
-    echo "" > utils/proof/src/lib.rs && \
-    echo "" > utils/signer/src/lib.rs && \
-    echo "" > utils/ethereum/client/src/lib.rs && \
-    echo "" > utils/ethereum/host/src/lib.rs && \
-    echo "" > utils/elfs/src/lib.rs && \
-    echo "" > programs/range/ethereum/src/lib.rs && \
-    echo "" > programs/range/celestia/src/lib.rs && \
-    echo "" > programs/range/eigenda/src/lib.rs && \
-    echo "" > programs/range/utils/src/lib.rs && \
-    echo "" > programs/aggregation/src/lib.rs && \
-    echo "" > scripts/prove/src/lib.rs && \
-    echo "" > scripts/utils/src/lib.rs && \
-    echo "" > validity/src/lib.rs && \
-    echo "" > bindings/src/lib.rs
+    echo "fn main() {}" > scripts/utils/bin/game-monitor.rs
 
 # Download and compile dependencies (this layer will be cached if Cargo.toml/Cargo.lock don't change)
-# The || true allows this to fail gracefully since we have dummy source files
-RUN cargo build --release --bin cost-estimator --features eigenda || true
-RUN cargo build --release --bin game-monitor || true
+# Build workspace libraries with actual source, but skip binaries (they have dummy source)
+# Use BuildKit cache mounts for faster Cargo operations
+# The || true allows this to fail gracefully if there are issues
+RUN --mount=type=cache,target=/root/.cargo/registry \
+    --mount=type=cache,target=/root/.cargo/git \
+    --mount=type=cache,target=/app/target \
+    cargo build --release --workspace --lib --features eigenda || true
 
-# Now copy the actual source code
-COPY fault-proof/src ./fault-proof/src
+# Now copy the actual binary source code
 COPY fault-proof/bin ./fault-proof/bin
-COPY utils/ ./utils/
-COPY programs/ ./programs/
-COPY scripts/ ./scripts/
-COPY validity/src ./validity/src
-COPY bindings/src ./bindings/src
+COPY scripts/utils/bin ./scripts/utils/bin
 
 # Build the actual binaries (only rebuilds if source changed)
-RUN cargo build --release --bin cost-estimator --features eigenda
-RUN cargo build --release --bin game-monitor
+# Use BuildKit cache mounts for faster builds
+RUN --mount=type=cache,target=/root/.cargo/registry \
+    --mount=type=cache,target=/root/.cargo/git \
+    --mount=type=cache,target=/app/target \
+    cargo build --release --bin cost-estimator --features eigenda && \
+    cargo build --release --bin game-monitor
 
 # Runtime stage (minimal image)
 FROM ubuntu:24.04

--- a/scripts/utils/Dockerfile.game-monitor
+++ b/scripts/utils/Dockerfile.game-monitor
@@ -107,21 +107,19 @@ RUN --mount=type=cache,target=/app/target \
     cp /app/target/release/cost-estimator /app/cost-estimator && \
     cp /app/target/release/game-monitor /app/game-monitor
 
-# Runtime stage (minimal image)
-FROM debian:trixie-slim
+# Runtime stage
+# Use rust image since cost-estimator needs cargo at runtime (calls cargo_metadata::MetadataCommand)
+FROM rust:1.89.0-trixie
 
 WORKDIR /app
 
-# Install only necessary runtime dependencies
-RUN apt-get update && apt-get install -y \
-    curl \
-    libssl-dev \
-    && rm -rf /var/lib/apt/lists/*
+# Copy toolchain file and install the specific toolchain version
+COPY rust-toolchain.toml .
+RUN rustup show
 
 # Copy workspace metadata files required by cargo_metadata::MetadataCommand
 # cost-estimator uses cargo_metadata to find the workspace root and create output directories
 COPY --from=builder /app/Cargo.toml /app/Cargo.lock ./
-COPY --from=builder /app/rust-toolchain.toml ./
 COPY --from=builder /app/fault-proof/Cargo.toml ./fault-proof/
 COPY --from=builder /app/utils/client/Cargo.toml ./utils/client/
 COPY --from=builder /app/utils/host/Cargo.toml ./utils/host/

--- a/scripts/utils/Dockerfile.game-monitor
+++ b/scripts/utils/Dockerfile.game-monitor
@@ -75,6 +75,8 @@ COPY validity/src ./validity/src
 COPY fault-proof/src ./fault-proof/src
 COPY scripts/utils/src ./scripts/utils/src
 COPY scripts/prove/src ./scripts/prove/src
+# Copy elf binaries needed by utils/elfs at compile time
+COPY elf/ ./elf/
 
 # Create dummy binary source files (binaries are what we're building, so we can cache their compilation)
 RUN mkdir -p fault-proof/bin && \

--- a/scripts/utils/Dockerfile.game-monitor
+++ b/scripts/utils/Dockerfile.game-monitor
@@ -85,8 +85,8 @@ RUN mkdir -p fault-proof/bin && \
 # Build workspace libraries with actual source, but skip binaries (they have dummy source)
 # Use BuildKit cache mounts for faster Cargo operations
 # The || true allows this to fail gracefully if there are issues
-RUN --mount=type=cache,target=/root/.cargo/registry \
-    --mount=type=cache,target=/root/.cargo/git \
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=/app/target \
     cargo build --release --workspace --lib --features eigenda || true
 
@@ -96,8 +96,8 @@ COPY scripts/utils/bin ./scripts/utils/bin
 
 # Build the actual binaries (only rebuilds if source changed)
 # Use BuildKit cache mounts for faster builds
-RUN --mount=type=cache,target=/root/.cargo/registry \
-    --mount=type=cache,target=/root/.cargo/git \
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=/app/target \
     cargo build --release --bin cost-estimator --features eigenda && \
     cargo build --release --bin game-monitor

--- a/scripts/utils/Dockerfile.game-monitor
+++ b/scripts/utils/Dockerfile.game-monitor
@@ -118,6 +118,33 @@ RUN apt-get update && apt-get install -y \
     libssl-dev \
     && rm -rf /var/lib/apt/lists/*
 
+# Copy workspace metadata files required by cargo_metadata::MetadataCommand
+# cost-estimator uses cargo_metadata to find the workspace root and create output directories
+COPY --from=builder /app/Cargo.toml /app/Cargo.lock ./
+COPY --from=builder /app/rust-toolchain.toml ./
+COPY --from=builder /app/fault-proof/Cargo.toml ./fault-proof/
+COPY --from=builder /app/utils/client/Cargo.toml ./utils/client/
+COPY --from=builder /app/utils/host/Cargo.toml ./utils/host/
+COPY --from=builder /app/utils/build/Cargo.toml ./utils/build/
+COPY --from=builder /app/utils/celestia/client/Cargo.toml ./utils/celestia/client/
+COPY --from=builder /app/utils/celestia/host/Cargo.toml ./utils/celestia/host/
+COPY --from=builder /app/utils/eigenda/client/Cargo.toml ./utils/eigenda/client/
+COPY --from=builder /app/utils/eigenda/host/Cargo.toml ./utils/eigenda/host/
+COPY --from=builder /app/utils/proof/Cargo.toml ./utils/proof/
+COPY --from=builder /app/utils/signer/Cargo.toml ./utils/signer/
+COPY --from=builder /app/utils/ethereum/client/Cargo.toml ./utils/ethereum/client/
+COPY --from=builder /app/utils/ethereum/host/Cargo.toml ./utils/ethereum/host/
+COPY --from=builder /app/utils/elfs/Cargo.toml ./utils/elfs/
+COPY --from=builder /app/programs/range/ethereum/Cargo.toml ./programs/range/ethereum/
+COPY --from=builder /app/programs/range/celestia/Cargo.toml ./programs/range/celestia/
+COPY --from=builder /app/programs/range/eigenda/Cargo.toml ./programs/range/eigenda/
+COPY --from=builder /app/programs/range/utils/Cargo.toml ./programs/range/utils/
+COPY --from=builder /app/programs/aggregation/Cargo.toml ./programs/aggregation/
+COPY --from=builder /app/scripts/prove/Cargo.toml ./scripts/prove/
+COPY --from=builder /app/scripts/utils/Cargo.toml ./scripts/utils/
+COPY --from=builder /app/validity/Cargo.toml ./validity/
+COPY --from=builder /app/bindings/Cargo.toml ./bindings/
+
 # Copy the built binaries (copied from cache mount to filesystem)
 COPY --from=builder /app/cost-estimator /usr/local/bin/
 COPY --from=builder /app/game-monitor /usr/local/bin/

--- a/scripts/utils/Dockerfile.game-monitor
+++ b/scripts/utils/Dockerfile.game-monitor
@@ -105,6 +105,11 @@ RUN --mount=type=cache,target=/root/.cargo/registry \
     cargo build --release --bin cost-estimator --features eigenda && \
     cargo build --release --bin game-monitor
 
+# Copy binaries from cache mount to filesystem so they can be copied to runtime stage
+RUN --mount=type=cache,target=/app/target \
+    cp /app/target/release/cost-estimator /app/cost-estimator && \
+    cp /app/target/release/game-monitor /app/game-monitor
+
 # Runtime stage (minimal image)
 FROM ubuntu:24.04
 
@@ -126,9 +131,9 @@ COPY rust-toolchain.toml .
 # This installs the nightly version from the file
 RUN rustup show
 
-# Copy the built binaries
-COPY --from=builder /app/target/release/cost-estimator /usr/local/bin/
-COPY --from=builder /app/target/release/game-monitor /usr/local/bin/
+# Copy the built binaries (copied from cache mount to filesystem)
+COPY --from=builder /app/cost-estimator /usr/local/bin/
+COPY --from=builder /app/game-monitor /usr/local/bin/
 
 # Copy the entire workspace so we can run cargo_metadata::MetadataCommand to get the workspace root.
 COPY . .

--- a/scripts/utils/Dockerfile.game-monitor
+++ b/scripts/utils/Dockerfile.game-monitor
@@ -78,8 +78,8 @@ RUN mkdir -p fault-proof/bin && \
     mkdir -p scripts/utils/bin && \
     echo "fn main() {}" > fault-proof/bin/proposer.rs && \
     echo "fn main() {}" > fault-proof/bin/challenger.rs && \
-    echo "fn main() {}" > scripts/utils/bin/cost-estimator.rs && \
-    echo "fn main() {}" > scripts/utils/bin/game-monitor.rs
+    echo "fn main() {}" > scripts/utils/bin/cost_estimator.rs && \
+    echo "fn main() {}" > scripts/utils/bin/game_monitor.rs
 
 # Download and compile dependencies (this layer will be cached if Cargo.toml/Cargo.lock don't change)
 # Build workspace libraries with actual source, but skip binaries (they have dummy source)

--- a/scripts/utils/Dockerfile.game-monitor
+++ b/scripts/utils/Dockerfile.game-monitor
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.4
 
 # Base stage: Install Rust and dependencies
-FROM ubuntu:24.04 AS rust-base
+FROM rust:1.89.0-trixie AS base
 
 WORKDIR /app
 
@@ -15,11 +15,6 @@ RUN apt-get update && apt-get install -y \
     libssl-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Rust
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-ENV PATH=/root/.cargo/bin:$PATH
-RUN rustup install stable && rustup default stable
-
 # Install SP1
 RUN curl -L https://sp1.succinct.xyz | bash && \
     ~/.sp1/bin/sp1up -v v5.2.2 && \
@@ -31,7 +26,7 @@ COPY rust-toolchain.toml .
 RUN rustup show
 
 # Build stage
-FROM rust-base AS builder
+FROM base AS builder
 
 WORKDIR /app
 
@@ -113,7 +108,7 @@ RUN --mount=type=cache,target=/app/target \
     cp /app/target/release/game-monitor /app/game-monitor
 
 # Runtime stage (minimal image)
-FROM ubuntu:24.04
+FROM debian:trixie-slim
 
 WORKDIR /app
 
@@ -123,19 +118,6 @@ RUN apt-get update && apt-get install -y \
     libssl-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Rust (needed by calls to cargo_metadata::MetadataCommand)
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-ENV PATH=/root/.cargo/bin:$PATH
-RUN rustup install stable && rustup default stable
-
-# Copy toolchain file
-COPY rust-toolchain.toml .
-# This installs the nightly version from the file
-RUN rustup show
-
 # Copy the built binaries (copied from cache mount to filesystem)
 COPY --from=builder /app/cost-estimator /usr/local/bin/
 COPY --from=builder /app/game-monitor /usr/local/bin/
-
-# Copy the entire workspace so we can run cargo_metadata::MetadataCommand to get the workspace root.
-COPY . .

--- a/scripts/utils/Dockerfile.game-monitor
+++ b/scripts/utils/Dockerfile.game-monitor
@@ -33,12 +33,97 @@ RUN rustup show
 # Build stage
 FROM rust-base AS builder
 
-# Copy the entire workspace
-COPY . .
+WORKDIR /app
 
-# Build the cost-estimator
+# Copy workspace root Cargo files
+COPY Cargo.toml Cargo.lock ./
+
+# Copy toolchain file (needed for dependency resolution)
+COPY rust-toolchain.toml ./
+
+# Copy all Cargo.toml files from workspace members
+# This allows Cargo to resolve dependencies without source
+COPY fault-proof/Cargo.toml ./fault-proof/
+COPY utils/client/Cargo.toml ./utils/client/
+COPY utils/host/Cargo.toml ./utils/host/
+COPY utils/build/Cargo.toml ./utils/build/
+COPY utils/celestia/client/Cargo.toml ./utils/celestia/client/
+COPY utils/celestia/host/Cargo.toml ./utils/celestia/host/
+COPY utils/eigenda/client/Cargo.toml ./utils/eigenda/client/
+COPY utils/eigenda/host/Cargo.toml ./utils/eigenda/host/
+COPY utils/proof/Cargo.toml ./utils/proof/
+COPY utils/signer/Cargo.toml ./utils/signer/
+COPY utils/ethereum/client/Cargo.toml ./utils/ethereum/client/
+COPY utils/ethereum/host/Cargo.toml ./utils/ethereum/host/
+COPY utils/elfs/Cargo.toml ./utils/elfs/
+COPY programs/range/ethereum/Cargo.toml ./programs/range/ethereum/
+COPY programs/range/celestia/Cargo.toml ./programs/range/celestia/
+COPY programs/range/eigenda/Cargo.toml ./programs/range/eigenda/
+COPY programs/range/utils/Cargo.toml ./programs/range/utils/
+COPY programs/aggregation/Cargo.toml ./programs/aggregation/
+COPY scripts/prove/Cargo.toml ./scripts/prove/
+COPY scripts/utils/Cargo.toml ./scripts/utils/
+COPY validity/Cargo.toml ./validity/
+COPY bindings/Cargo.toml ./bindings/
+
+# Create dummy source files to satisfy Cargo's dependency resolution
+# This allows us to download and compile dependencies without the actual source
+RUN mkdir -p fault-proof/src fault-proof/bin && \
+    mkdir -p utils/client/src utils/host/src utils/build/src && \
+    mkdir -p utils/celestia/client/src utils/celestia/host/src && \
+    mkdir -p utils/eigenda/client/src utils/eigenda/host/src && \
+    mkdir -p utils/proof/src utils/signer/src && \
+    mkdir -p utils/ethereum/client/src utils/ethereum/host/src && \
+    mkdir -p utils/elfs/src && \
+    mkdir -p programs/range/ethereum/src programs/range/celestia/src && \
+    mkdir -p programs/range/eigenda/src programs/range/utils/src && \
+    mkdir -p programs/aggregation/src && \
+    mkdir -p scripts/prove/src scripts/utils/src && \
+    mkdir -p scripts/utils/bin && \
+    mkdir -p validity/src bindings/src && \
+    echo "fn main() {}" > fault-proof/bin/proposer.rs && \
+    echo "fn main() {}" > fault-proof/bin/challenger.rs && \
+    echo "fn main() {}" > scripts/utils/bin/cost-estimator.rs && \
+    echo "fn main() {}" > scripts/utils/bin/game-monitor.rs && \
+    echo "" > fault-proof/src/lib.rs && \
+    echo "" > utils/client/src/lib.rs && \
+    echo "" > utils/host/src/lib.rs && \
+    echo "" > utils/build/src/lib.rs && \
+    echo "" > utils/celestia/client/src/lib.rs && \
+    echo "" > utils/celestia/host/src/lib.rs && \
+    echo "" > utils/eigenda/client/src/lib.rs && \
+    echo "" > utils/eigenda/host/src/lib.rs && \
+    echo "" > utils/proof/src/lib.rs && \
+    echo "" > utils/signer/src/lib.rs && \
+    echo "" > utils/ethereum/client/src/lib.rs && \
+    echo "" > utils/ethereum/host/src/lib.rs && \
+    echo "" > utils/elfs/src/lib.rs && \
+    echo "" > programs/range/ethereum/src/lib.rs && \
+    echo "" > programs/range/celestia/src/lib.rs && \
+    echo "" > programs/range/eigenda/src/lib.rs && \
+    echo "" > programs/range/utils/src/lib.rs && \
+    echo "" > programs/aggregation/src/lib.rs && \
+    echo "" > scripts/prove/src/lib.rs && \
+    echo "" > scripts/utils/src/lib.rs && \
+    echo "" > validity/src/lib.rs && \
+    echo "" > bindings/src/lib.rs
+
+# Download and compile dependencies (this layer will be cached if Cargo.toml/Cargo.lock don't change)
+# The || true allows this to fail gracefully since we have dummy source files
+RUN cargo build --release --bin cost-estimator --features eigenda || true
+RUN cargo build --release --bin game-monitor || true
+
+# Now copy the actual source code
+COPY fault-proof/src ./fault-proof/src
+COPY fault-proof/bin ./fault-proof/bin
+COPY utils/ ./utils/
+COPY programs/ ./programs/
+COPY scripts/ ./scripts/
+COPY validity/src ./validity/src
+COPY bindings/src ./bindings/src
+
+# Build the actual binaries (only rebuilds if source changed)
 RUN cargo build --release --bin cost-estimator --features eigenda
-# Build the game-monitor
 RUN cargo build --release --bin game-monitor
 
 # Runtime stage (minimal image)

--- a/scripts/utils/Dockerfile.parallel-cost-estimator
+++ b/scripts/utils/Dockerfile.parallel-cost-estimator
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.4
 
 # Build stage with full development environment
-FROM ubuntu:24.04 AS builder
+FROM rust:1.89.0-trixie AS base
 
 WORKDIR /workspace
 
@@ -16,10 +16,6 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Rust
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-ENV PATH=/root/.cargo/bin:$PATH
-
 # Copy rust-toolchain from workspace root
 COPY rust-toolchain.toml ./
 RUN rustup show && \
@@ -31,15 +27,124 @@ RUN curl -L https://sp1.succinct.xyz | bash && \
     ~/.sp1/bin/cargo-prove prove --version
 ENV PATH=/root/.sp1/bin:$PATH
 
-# Copy entire workspace
-COPY . .
+FROM base AS builder
 
-# Build both binaries
-RUN cargo build --release --bin cost-estimator --features eigenda && \
+WORKDIR /workspace
+
+# Copy workspace root Cargo files
+COPY Cargo.toml Cargo.lock ./
+
+# Copy toolchain file (needed for dependency resolution)
+COPY rust-toolchain.toml ./
+
+# Copy all Cargo.toml files from workspace members
+# This allows Cargo to resolve dependencies without source
+COPY fault-proof/Cargo.toml ./fault-proof/
+COPY utils/client/Cargo.toml ./utils/client/
+COPY utils/host/Cargo.toml ./utils/host/
+COPY utils/build/Cargo.toml ./utils/build/
+COPY utils/celestia/client/Cargo.toml ./utils/celestia/client/
+COPY utils/celestia/host/Cargo.toml ./utils/celestia/host/
+COPY utils/eigenda/client/Cargo.toml ./utils/eigenda/client/
+COPY utils/eigenda/host/Cargo.toml ./utils/eigenda/host/
+COPY utils/proof/Cargo.toml ./utils/proof/
+COPY utils/signer/Cargo.toml ./utils/signer/
+COPY utils/ethereum/client/Cargo.toml ./utils/ethereum/client/
+COPY utils/ethereum/host/Cargo.toml ./utils/ethereum/host/
+COPY utils/elfs/Cargo.toml ./utils/elfs/
+COPY programs/range/ethereum/Cargo.toml ./programs/range/ethereum/
+COPY programs/range/celestia/Cargo.toml ./programs/range/celestia/
+COPY programs/range/eigenda/Cargo.toml ./programs/range/eigenda/
+COPY programs/range/utils/Cargo.toml ./programs/range/utils/
+COPY programs/aggregation/Cargo.toml ./programs/aggregation/
+COPY scripts/prove/Cargo.toml ./scripts/prove/
+COPY scripts/utils/Cargo.toml ./scripts/utils/
+COPY validity/Cargo.toml ./validity/
+COPY bindings/Cargo.toml ./bindings/
+
+# Copy elf binaries needed by utils/elfs at compile time (needed before building)
+COPY elf/ ./elf/
+
+# Create dummy source files to satisfy Cargo's dependency resolution
+# This allows us to download and compile dependencies without the actual source
+RUN mkdir -p fault-proof/src fault-proof/bin && \
+    mkdir -p utils/client/src utils/host/src utils/build/src && \
+    mkdir -p utils/celestia/client/src utils/celestia/host/src && \
+    mkdir -p utils/eigenda/client/src utils/eigenda/host/src && \
+    mkdir -p utils/proof/src utils/signer/src && \
+    mkdir -p utils/ethereum/client/src utils/ethereum/host/src && \
+    mkdir -p utils/elfs/src && \
+    mkdir -p programs/range/ethereum/src programs/range/celestia/src && \
+    mkdir -p programs/range/eigenda/src programs/range/utils/src && \
+    mkdir -p programs/aggregation/src && \
+    mkdir -p scripts/prove/src scripts/utils/src scripts/utils/bin && \
+    mkdir -p validity/src bindings/src && \
+    echo "fn main() {}" > fault-proof/bin/proposer.rs && \
+    echo "fn main() {}" > fault-proof/bin/challenger.rs && \
+    echo "fn main() {}" > scripts/utils/bin/cost-estimator.rs && \
+    echo "fn main() {}" > scripts/utils/bin/parallel-cost-estimator.rs && \
+    echo "" > fault-proof/src/lib.rs && \
+    echo "" > utils/client/src/lib.rs && \
+    echo "" > utils/host/src/lib.rs && \
+    echo "" > utils/build/src/lib.rs && \
+    echo "" > utils/celestia/client/src/lib.rs && \
+    echo "" > utils/celestia/host/src/lib.rs && \
+    echo "" > utils/eigenda/client/src/lib.rs && \
+    echo "" > utils/eigenda/host/src/lib.rs && \
+    echo "" > utils/proof/src/lib.rs && \
+    echo "" > utils/signer/src/lib.rs && \
+    echo "" > utils/ethereum/client/src/lib.rs && \
+    echo "" > utils/ethereum/host/src/lib.rs && \
+    echo "" > utils/elfs/src/lib.rs && \
+    echo "" > programs/range/ethereum/src/lib.rs && \
+    echo "" > programs/range/celestia/src/lib.rs && \
+    echo "" > programs/range/eigenda/src/lib.rs && \
+    echo "" > programs/range/utils/src/lib.rs && \
+    echo "" > programs/aggregation/src/lib.rs && \
+    echo "" > scripts/prove/src/lib.rs && \
+    echo "" > scripts/utils/src/lib.rs && \
+    echo "" > validity/src/lib.rs && \
+    echo "" > bindings/src/lib.rs
+
+# Download and compile dependencies (this layer will be cached if Cargo.toml/Cargo.lock don't change)
+# Use BuildKit cache mounts for faster Cargo operations
+# The || true allows this to fail gracefully since we have dummy source files
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/workspace/target \
+    cargo build --release --bin cost-estimator --features eigenda || true
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/workspace/target \
+    cargo build --release --bin parallel-cost-estimator --features eigenda || true
+
+# Now copy the actual source code
+COPY fault-proof/src ./fault-proof/src
+COPY fault-proof/bin ./fault-proof/bin
+COPY utils/ ./utils/
+COPY programs/ ./programs/
+COPY scripts/ ./scripts/
+COPY validity/src ./validity/src
+COPY bindings/src ./bindings/src
+COPY resources/ ./resources/
+
+# Build the actual binaries (only rebuilds if source changed)
+# Use BuildKit cache mounts for faster builds
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/workspace/target \
+    cargo build --release --bin cost-estimator --features eigenda && \
     cargo build --release --bin parallel-cost-estimator --features eigenda
 
-# Runtime stage - minimal image
-FROM ubuntu:24.04
+# Copy binaries from cache mount to filesystem so they can be copied to runtime stage
+RUN --mount=type=cache,target=/workspace/target \
+    cp /workspace/target/release/cost-estimator /workspace/cost-estimator && \
+    cp /workspace/target/release/parallel-cost-estimator /workspace/parallel-cost-estimator
+
+# Runtime stage
+# Use rust image since cost-estimator needs cargo at runtime (calls cargo_metadata::MetadataCommand)
+FROM rust:1.89.0-trixie
 
 WORKDIR /app
 
@@ -48,17 +153,19 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     libssl3 \
     && rm -rf /var/lib/apt/lists/*
+# Copy toolchain file and install the specific toolchain version
+COPY rust-toolchain.toml .
+RUN rustup show
 
 # Copy resources directory
 COPY --from=builder /workspace/resources/ ./resources/
 
-# Copy only the built binaries
-COPY --from=builder /workspace/target/release/cost-estimator /usr/local/bin/cost-estimator
-COPY --from=builder /workspace/target/release/parallel-cost-estimator /usr/local/bin/parallel-cost-estimator
+# Copy only the built binaries (copied from cache mount to filesystem)
+COPY --from=builder /workspace/cost-estimator /usr/local/bin/cost-estimator
+COPY --from=builder /workspace/parallel-cost-estimator /usr/local/bin/parallel-cost-estimator
 
 # Set environment variable to use the built cost-estimator binary
 ENV COST_ESTIMATOR_BIN=/usr/local/bin/cost-estimator
 
 # Default command
 CMD ["parallel-cost-estimator"]
-

--- a/scripts/utils/Dockerfile.parallel-cost-estimator
+++ b/scripts/utils/Dockerfile.parallel-cost-estimator
@@ -79,8 +79,8 @@ RUN mkdir -p fault-proof/bin && \
     mkdir -p scripts/utils/bin && \
     echo "fn main() {}" > fault-proof/bin/proposer.rs && \
     echo "fn main() {}" > fault-proof/bin/challenger.rs && \
-    echo "fn main() {}" > scripts/utils/bin/cost-estimator.rs && \
-    echo "fn main() {}" > scripts/utils/bin/parallel-cost-estimator.rs
+    echo "fn main() {}" > scripts/utils/bin/cost_estimator.rs && \
+    echo "fn main() {}" > scripts/utils/bin/parallel_cost_estimator.rs
 
 # Download and compile dependencies (this layer will be cached if Cargo.toml/Cargo.lock don't change)
 # Build workspace libraries with actual source, but skip binaries (they have dummy source)

--- a/scripts/utils/Dockerfile.parallel-cost-estimator
+++ b/scripts/utils/Dockerfile.parallel-cost-estimator
@@ -62,71 +62,38 @@ COPY scripts/utils/Cargo.toml ./scripts/utils/
 COPY validity/Cargo.toml ./validity/
 COPY bindings/Cargo.toml ./bindings/
 
-# Copy elf binaries needed by utils/elfs at compile time (needed before building)
+# Copy actual source code for library crates (needed for dependency compilation)
+# These are workspace dependencies that other crates import from
+COPY utils/ ./utils/
+COPY programs/ ./programs/
+COPY bindings/src ./bindings/src
+COPY validity/src ./validity/src
+COPY fault-proof/src ./fault-proof/src
+COPY scripts/utils/src ./scripts/utils/src
+COPY scripts/prove/src ./scripts/prove/src
+# Copy elf binaries needed by utils/elfs at compile time
 COPY elf/ ./elf/
 
-# Create dummy source files to satisfy Cargo's dependency resolution
-# This allows us to download and compile dependencies without the actual source
-RUN mkdir -p fault-proof/src fault-proof/bin && \
-    mkdir -p utils/client/src utils/host/src utils/build/src && \
-    mkdir -p utils/celestia/client/src utils/celestia/host/src && \
-    mkdir -p utils/eigenda/client/src utils/eigenda/host/src && \
-    mkdir -p utils/proof/src utils/signer/src && \
-    mkdir -p utils/ethereum/client/src utils/ethereum/host/src && \
-    mkdir -p utils/elfs/src && \
-    mkdir -p programs/range/ethereum/src programs/range/celestia/src && \
-    mkdir -p programs/range/eigenda/src programs/range/utils/src && \
-    mkdir -p programs/aggregation/src && \
-    mkdir -p scripts/prove/src scripts/utils/src scripts/utils/bin && \
-    mkdir -p validity/src bindings/src && \
+# Create dummy binary source files (binaries are what we're building, so we can cache their compilation)
+RUN mkdir -p fault-proof/bin && \
+    mkdir -p scripts/utils/bin && \
     echo "fn main() {}" > fault-proof/bin/proposer.rs && \
     echo "fn main() {}" > fault-proof/bin/challenger.rs && \
     echo "fn main() {}" > scripts/utils/bin/cost-estimator.rs && \
-    echo "fn main() {}" > scripts/utils/bin/parallel-cost-estimator.rs && \
-    echo "" > fault-proof/src/lib.rs && \
-    echo "" > utils/client/src/lib.rs && \
-    echo "" > utils/host/src/lib.rs && \
-    echo "" > utils/build/src/lib.rs && \
-    echo "" > utils/celestia/client/src/lib.rs && \
-    echo "" > utils/celestia/host/src/lib.rs && \
-    echo "" > utils/eigenda/client/src/lib.rs && \
-    echo "" > utils/eigenda/host/src/lib.rs && \
-    echo "" > utils/proof/src/lib.rs && \
-    echo "" > utils/signer/src/lib.rs && \
-    echo "" > utils/ethereum/client/src/lib.rs && \
-    echo "" > utils/ethereum/host/src/lib.rs && \
-    echo "" > utils/elfs/src/lib.rs && \
-    echo "" > programs/range/ethereum/src/lib.rs && \
-    echo "" > programs/range/celestia/src/lib.rs && \
-    echo "" > programs/range/eigenda/src/lib.rs && \
-    echo "" > programs/range/utils/src/lib.rs && \
-    echo "" > programs/aggregation/src/lib.rs && \
-    echo "" > scripts/prove/src/lib.rs && \
-    echo "" > scripts/utils/src/lib.rs && \
-    echo "" > validity/src/lib.rs && \
-    echo "" > bindings/src/lib.rs
+    echo "fn main() {}" > scripts/utils/bin/parallel-cost-estimator.rs
 
 # Download and compile dependencies (this layer will be cached if Cargo.toml/Cargo.lock don't change)
+# Build workspace libraries with actual source, but skip binaries (they have dummy source)
 # Use BuildKit cache mounts for faster Cargo operations
-# The || true allows this to fail gracefully since we have dummy source files
+# The || true allows this to fail gracefully if there are issues
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=/workspace/target \
-    cargo build --release --bin cost-estimator --features eigenda || true
+    cargo build --release --workspace --lib --features eigenda || true
 
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/usr/local/cargo/git \
-    --mount=type=cache,target=/workspace/target \
-    cargo build --release --bin parallel-cost-estimator --features eigenda || true
-
-# Now copy the actual source code
-COPY fault-proof/src ./fault-proof/src
+# Now copy the actual binary source code
 COPY fault-proof/bin ./fault-proof/bin
-COPY utils/ ./utils/
-COPY programs/ ./programs/
-COPY scripts/ ./scripts/
-COPY validity/src ./validity/src
-COPY bindings/src ./bindings/src
+COPY scripts/utils/bin ./scripts/utils/bin
 COPY resources/ ./resources/
 
 # Build the actual binaries (only rebuilds if source changed)


### PR DESCRIPTION
Changes:
- `infer_image_metadata` switched to `ubuntu-slim` runner (as is a very simple job, best is prioritizing runner startup time)
- Updated the `docker-build.yaml` reusable workflow to a new version with information about the time of each step in the action

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds change-detection to conditionally build dev images, overhauls Rust Dockerfiles for faster cached builds and slimmer runtimes, and switches ELF workflow to a self-hosted runner with explicit toolchains and ELF integrity check.
> 
> - **CI/Workflows**:
>   - **Conditional builds**: Add `detect_changes` using `dorny/paths-filter` to gate dev image builds for `proposer`, `challenger`, `game-monitor`, and `parallel-cost-estimator`.
>   - **ELF workflow**: Run on self-hosted runner; install Rust/SP1; build Ethereum/EigenDA/aggregation ELFs; fail if `elf/` changes; setup Buildx.
>   - **Reusable workflow updates**: Bump `docker-build.yaml` to `v3.1.0-rc.4`; run `infer_image_metadata` on `ubuntu-slim`; run SQLx check on `ubuntu-slim`; update `actions/checkout` to `v6`; use `github.token` for misspell.
> - **Docker images**:
>   - **Rust services** (`fault-proof` proposer/challenger, `scripts/utils` game-monitor & parallel-cost-estimator): convert to multi-stage builds with Cargo manifest layering, dummy sources, and BuildKit cache mounts; copy `elf/` for compile-time; install SP1 in base.
>   - **Runtime**: switch to `debian:trixie-slim` (or Rust runtime where needed); include `libssl3` and `ca-certificates`; copy `resources/`; export built binaries from cached targets.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5e3e228c0818e1ae177ed2a10f81efb7f918a2c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->