### PR TITLE
Add create_new_game_branch script for runbook

### DIFF
--- a/celo/.env.example
+++ b/celo/.env.example
@@ -2,4 +2,6 @@ PROPOSER_PK=
 L1_RPC_URL=
 L2_NODE_URL=
 DISPUTE_FACTORY_ADDRESS=
+# PROPOSAL_INTERVAL should be different from the L2 block number diff between challenged game and its parent to differentiate the game UUID
 PROPOSAL_INTERVAL=
+CHALLENGED_GAME_INDEX=

--- a/celo/create_new_game_branch.sh
+++ b/celo/create_new_game_branch.sh
@@ -1,6 +1,18 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Usage: 
+# ./create_new_game_branch.sh .env.example
+#
+# Description:
+# This script creates a new game branch to recover from CHALLENGER_WINS game chain. It fetches the 
+# parent game information, calculates the target L2 block number based on the proposal interval,
+# retrieves the output root for that block, and creates a new game by calling the dispute factory's
+# create() function.
+#
+# This script is part of the Succinct Dispute Game Recovery runbook:
+# https://www.notion.so/clabsco/Succinct-Dispute-Game-Recovery-Handling-Proving-Failures-2c3ea6297b89801b87a7c47d97ba8a35?source=copy_link
+
 # Optional: load env vars from file passed as first argument
 if (( $# >= 1 )) && [[ -n "${1:-}" ]]; then
   ENV_FILE="$1"
@@ -21,6 +33,7 @@ required_vars=(
   L1_RPC_URL
   L2_NODE_URL
   DISPUTE_FACTORY_ADDRESS
+  CHALLENGED_GAME_INDEX
   PROPOSAL_INTERVAL
 )
 
@@ -36,16 +49,7 @@ init_bond_hex=$(cast call "$DISPUTE_FACTORY_ADDRESS" "initBonds(uint32)" 42 -r "
 init_bond=$(cast --to-dec "$init_bond_hex")
 echo "Init bond: $init_bond"
 
-echo "Fetching game count..."
-game_count_hex=$(cast call "$DISPUTE_FACTORY_ADDRESS" "gameCount()" -r "$L1_RPC_URL")
-game_count=$(cast --to-dec "$game_count_hex")
-
-if (( game_count <= 0 )); then
-  echo "Error: No existing games found (game_count=$game_count). Cannot derive parent index." >&2
-  exit 1
-fi
-
-parent_index=$(( game_count - 1 ))
+parent_index=$(( CHALLENGED_GAME_INDEX - 1 ))
 echo "Parent index: $parent_index"
 
 echo "Fetching parent game tuple (type,timestamp,address)..."
@@ -61,14 +65,7 @@ if [ $cast_exit_code -ne 0 ] || [ -z "$result" ]; then
 fi
 
 # Parse the result - it comes as multiple lines
-game_type=$(echo "$result" | head -n1)
 parent_address=$(echo "$result" | tail -n1)
-
-if [ $game_type -ne 1 ]; then
-    echo "Error: Parent game is not of type 1." >&2
-    exit 1
-fi
-
 echo "Parent game proxy address: $parent_address"
 
 echo "Fetching parent game's L2 block number..."


### PR DESCRIPTION
Added a script that creates a new game branch to recover from `CHALLENGER_WINS` game chain. This script is part of the [Succinct Dispute Game Recovery runbook](https://www.notion.so/clabsco/Succinct-Dispute-Game-Recovery-Handling-Proving-Failures-2c3ea6297b89801b87a7c47d97ba8a35?source=copy_link).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a recovery script to create a new dispute game branch using a specified challenged game index and proposal interval, and updates env variables accordingly.
> 
> - **Scripts**:
>   - **`celo/create_new_game_branch.sh`**: New script to create a new dispute game branch.
>     - Loads optional env file; validates required vars (`PROPOSER_PK`, `L1_RPC_URL`, `L2_NODE_URL`, `DISPUTE_FACTORY_ADDRESS`, `CHALLENGED_GAME_INDEX`, `PROPOSAL_INTERVAL`).
>     - Derives `parent_index` from `CHALLENGED_GAME_INDEX - 1`; fetches parent game address and its L2 block.
>     - Validates `PROPOSAL_INTERVAL`, computes target L2 block, fetches `outputRoot` via `optimism_outputAtBlock` from `L2_NODE_URL` (requires `jq`).
>     - Builds `extra_data` (32-byte L2 block number || 4-byte parent index) and sends `create(uint32,bytes32,bytes)` tx to `DISPUTE_FACTORY_ADDRESS` with `initBonds` value.
>     - Removes prior logic that inferred `parent_index` from `gameCount` and game type checks.
> - **Config**:
>   - **`celo/.env.example`**: Adds guidance for `PROPOSAL_INTERVAL` and introduces `CHALLENGED_GAME_INDEX` env var.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ef8a6ece1ce846113bb4fa48260dc63db236220. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->