### PR TITLE
fix docker cache

### DIFF
--- a/.github/workflows/push-container.yaml
+++ b/.github/workflows/push-container.yaml
@@ -52,7 +52,7 @@ jobs:
         && inputs.concurrency-group
         || format('{0}-{1}', github.workflow, (github.head_ref != '' && github.head_ref || github.ref)) }}
       cancel-in-progress: true
-    uses: celo-org/reusable-workflows/.github/workflows/docker-build.yaml@v3.1.0-rc.4
+    uses: celo-org/reusable-workflows/.github/workflows/docker-build.yaml@v3.1.0-rc.3
     with:
       runs-on: '["self-hosted", "org", "8-cpu"]'
       workload-id-provider: ${{ inputs.workload-id-provider }}

--- a/fault-proof/Dockerfile.challenger.celo
+++ b/fault-proof/Dockerfile.challenger.celo
@@ -99,7 +99,6 @@ RUN mkdir -p fault-proof/src fault-proof/bin && \
 # The || true allows this to fail gracefully since we have dummy source files
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
-    --mount=type=cache,target=/app/target \
     cargo build --release --bin challenger --features eigenda || true
 
 # Now copy the actual source code
@@ -115,12 +114,7 @@ COPY bindings/src ./bindings/src
 # Use BuildKit cache mounts for faster builds
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
-    --mount=type=cache,target=/app/target \
     cargo build --release --bin challenger --features eigenda
-
-# Copy binary from cache mount to filesystem so it can be copied to runtime stage
-RUN --mount=type=cache,target=/app/target \
-    cp /app/target/release/challenger /app/challenger
 
 # Runtime stage (minimal image - only runtime dependencies)
 FROM debian:trixie-slim
@@ -137,7 +131,7 @@ RUN apt-get update && apt-get install -y \
 COPY resources/ ./resources/
 
 # Copy the built challenger binary (copied from cache mount to filesystem)
-COPY --from=builder /app/challenger /usr/local/bin/
+COPY --from=builder /app/target/release/challenger /usr/local/bin/
 
 # Set the command
 CMD ["challenger"]

--- a/fault-proof/Dockerfile.proposer.celo
+++ b/fault-proof/Dockerfile.proposer.celo
@@ -99,7 +99,6 @@ RUN mkdir -p fault-proof/src fault-proof/bin && \
 # The || true allows this to fail gracefully since we have dummy source files
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
-    --mount=type=cache,target=/app/target \
     cargo build --release --bin proposer --features eigenda || true
 
 # Now copy the actual source code
@@ -115,12 +114,7 @@ COPY bindings/src ./bindings/src
 # Use BuildKit cache mounts for faster builds
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
-    --mount=type=cache,target=/app/target \
     cargo build --release --bin proposer --features eigenda
-
-# Copy binary from cache mount to filesystem so it can be copied to runtime stage
-RUN --mount=type=cache,target=/app/target \
-    cp /app/target/release/proposer /app/proposer
 
 # Runtime stage (minimal image - only runtime dependencies)
 FROM debian:trixie-slim
@@ -137,7 +131,7 @@ RUN apt-get update && apt-get install -y \
 COPY resources/ ./resources/
 
 # Copy the built proposer binary (copied from cache mount to filesystem)
-COPY --from=builder /app/proposer /usr/local/bin/
+COPY --from=builder /app/target/release/proposer /usr/local/bin/
 
 # Set the command
 CMD ["proposer"]


### PR DESCRIPTION
`--mount=type=cache,target=/app/target` BuildKit local cache-mounts will remove the target directory from the layer cache. This means that depdency-only layers can not be cached in-between CI runs. 


```
# Use BuildKit cache mounts for faster builds
RUN --mount=type=cache,target=/usr/local/cargo/registry \
    --mount=type=cache,target=/usr/local/cargo/git \
    --mount=type=cache,target=/app/target \
    cargo build --release --bin challenger --features eigenda
```
 In addition, since the filesystem does not change due to the exclusion of the target dir,
copying the final binary can trigger a cache-hit from a previous build and thus import an incorrect binary.
This resulted in several, code-altering PRs having the same docker-image uploaded to the registry.

```
RUN --mount=type=cache,target=/app/target \
    cp /app/target/release/challenger /app/challenger
```

## Changes
- **reverted `celo-org/reusable-workflows/.github/workflows/docker-build.yaml@v3.1.0-rc.4` back to `v3.1.0-rc.3`:**
The `v3.1.0-rc.4` version was internally relying on `docker-build-composite-action@v1.0.3`, which changed the build-kit cache-to and cache-from from its multi-stage build. This would make the second build, that previously was cached locally on the ephemeral runner always rebuild. Additionally the `min` cache introduced would not cache intermediary docker build steps.

- **removed the local BuildKit mount-cacheing of the target dir:**
As explained above, mounting `--mount=type=cache,target=/app/target` for `RUN` commands on a local cache-mount will exclude it's resulting file-content from the externally persisted layer-cache.
This will not only make rust dependency-only builds not cache across CI runs, but can also result in wrongfully getting a cache-hit for copying the target binary from the builder stage to the final stage, and thus copying an older build into the docker image.