### PR TITLE
Fix script to generate safe tx.

### DIFF
--- a/contracts/script/fp/ConfigureDeploymentSafe.s.sol
+++ b/contracts/script/fp/ConfigureDeploymentSafe.s.sol
@@ -67,16 +67,16 @@ contract ConfigureDeploymentSafe is Script, Utils {
         calls[_op] = IMulticall3.Call3(
             config.factoryProxy,
             false,
-            abi.encodeWithSelector(DisputeGameFactory.setInitBond.selector, gameType, config.initialBondWei)
+            abi.encodeWithSelector(
+                DisputeGameFactory.setImplementation.selector, gameType, IDisputeGame(config.gameImplementation)
+            )
         );
         if (config.initialBondWei != 0) {
             _op++;
             calls[_op] = IMulticall3.Call3(
                 config.factoryProxy,
                 false,
-                abi.encodeWithSelector(
-                    DisputeGameFactory.setImplementation.selector, gameType, IDisputeGame(config.gameImplementation)
-                )
+                abi.encodeWithSelector(DisputeGameFactory.setInitBond.selector, gameType, config.initialBondWei)
             );
         }
         if (config.optimismPortal2 != address(0)) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fixes `ConfigureDeploymentSafe.s.sol` to build the Safe multicall in the correct order.
> 
> - First call now sets `DisputeGameFactory.setImplementation` for the `gameType`
> - Conditional second call sets `DisputeGameFactory.setInitBond` when `initialBondWei != 0`
> - Optional portal update (`IOptimismPortal2.setRespectedGameType`) remains as the final call when configured
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 799e79ca16974e9868f7c228d37354508eca05b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->