### PR TITLE
Add proposer identity to celo/v1.0.2 to support hardfork transition

### DIFF
--- a/book/fault_proofs/proposer.md
+++ b/book/fault_proofs/proposer.md
@@ -234,6 +234,117 @@ Key components:
 - `resolve_games` / `claim_bonds`: Submit on-chain transactions for eligible games and trim settled entries from the cache.
 - `run`: Orchestrates the periodic loop, delegating work to the task scheduler.
 
+## Hardfork Transitions
+
+The proposer supports zero-downtime hardfork transitions through automatic vkey validation. When on-chain verification keys change (indicating a new game implementation), the old proposer gracefully stops creating new games while continuing to service its existing games until completion.
+
+### Proposer Identity
+
+At startup, the proposer computes its identity from three fields derived from the SP1 ELF programs and rollup configuration:
+
+| Field | Source | Purpose |
+|-------|--------|---------|
+| `aggregation_vkey` | Aggregation program ELF | Identifies the aggregation circuit version |
+| `range_vkey_commitment` | Range program ELF | Identifies the range circuit version |
+| `rollup_config_hash` | Rollup config file | Identifies the chain configuration |
+
+These values are logged at startup for operator visibility:
+
+```
+INFO Proposer initialized version="3.4.1-ethereum" aggregation_vkey="0x1234abcd..." range_vkey_commitment="0x5678efgh..." rollup_config_hash="0x9abc..."
+```
+
+### Owned vs Foreign Games
+
+The proposer classifies each game in the dispute DAG as either **owned** or **foreign** based on whether the game's identity fields match the proposer's:
+
+| Classification | Condition | Proposer Actions |
+|---------------|-----------|------------------|
+| **Owned** | All 3 identity fields match | Create, defend, prove, resolve, claim bonds |
+| **Foreign** | Any identity field differs | Track in DAG for canonical head calculation only |
+
+Foreign games are still tracked because they affect the canonical head calculation—new games must be proposed on top of the current canonical head regardless of which proposer created it.
+
+### Hardfork Detection
+
+Before creating a new game, the proposer calls `on_chain_vkeys_match()` to compare its identity against the factory's current game implementation:
+
+1. Query the factory for the current game implementation address
+2. Read `aggregationVkey`, `rangeVkeyCommitment`, and `rollupConfigHash` from the implementation
+3. Compare all three values against the proposer's identity
+
+If any value differs, the proposer logs:
+```
+INFO Proposer vkeys mismatch with on-chain vkeys - skipping game creation (hardfork detected)
+```
+
+This check runs on every iteration of the proposer loop, so the transition is immediate once the on-chain implementation is upgraded.
+
+### Behavior During Hardfork
+
+When a hardfork is detected, the proposer's behavior changes:
+
+| Operation | Before Hardfork | After Hardfork |
+|-----------|-----------------|----------------|
+| **Game Creation** | Creates new games | Skips (vkey mismatch) |
+| **Game Defense** | Defends challenged games | Defends owned games only |
+| **Game Resolution** | Resolves eligible games | Resolves owned games only |
+| **Bond Claiming** | Claims from finalized games | Claims from owned games only |
+
+The proposer continues running and servicing owned games until all have been resolved and bonds claimed.
+
+### Zero-Downtime Transition Workflow
+
+To perform a hardfork with zero downtime:
+
+1. **Deploy new game implementation**
+   ```bash
+   just upgrade-game-impl
+   ```
+   This updates the factory to use the new implementation with updated vkeys.
+
+2. **Start new proposer**
+
+   Launch a new proposer instance with the updated ELF programs. It will immediately begin creating games using the new vkeys.
+
+3. **Keep old proposer running**
+
+   The old proposer detects the hardfork and stops creating games, but continues to:
+   - Defend any challenged owned games
+   - Resolve owned games once eligible
+   - Claim bonds from finalized owned games
+
+4. **Monitor transition**
+
+   Watch logs from both proposers. The old proposer will show:
+   ```
+   INFO Proposer vkeys mismatch with on-chain vkeys - skipping game creation (hardfork detected)
+   ```
+
+5. **Shutdown old proposer**
+
+   Once the old proposer has no remaining owned games (all resolved and bonds claimed), it can be safely shut down.
+
+**Timeline**: Games may take up to `MAX_CHALLENGE_DURATION + MAX_PROVE_DURATION` to fully resolve after the hardfork. Plan for the old proposer to run for this duration.
+
+### Logging and Monitoring
+
+Key log messages to monitor during transitions:
+
+| Log Message | Meaning |
+|-------------|---------|
+| `Proposer initialized version=...` | Proposer started with specific identity |
+| `Proposer vkeys mismatch...hardfork detected` | Hardfork detected, game creation disabled |
+| `Game created successfully` | New game proposed (new proposer) |
+| `Game proven successfully` | Defense completed for owned game |
+| `Resolved game` | Game resolution transaction submitted |
+| `Claimed bond` | Bond recovered from finalized game |
+
+Recommended alerts:
+- Alert when hardfork detection message appears (transition in progress)
+- Alert if old proposer has owned games remaining after expected duration
+- Monitor both proposers' game counts during transition period
+
 ## Development
 
 When developing or modifying the proposer:

--- a/contracts/script/fp/UpgradeOPSuccinctFDG.s.sol
+++ b/contracts/script/fp/UpgradeOPSuccinctFDG.s.sol
@@ -18,7 +18,7 @@ import {DisputeGameFactory} from "src/dispute/DisputeGameFactory.sol";
 import {AccessManager} from "../../src/fp/AccessManager.sol";
 
 contract UpgradeOPSuccinctFDG is Script {
-    function run() public {
+    function run() public returns (address gameImpl) {
         vm.startBroadcast();
 
         // Get the factory.
@@ -50,6 +50,8 @@ contract UpgradeOPSuccinctFDG is Script {
         }
 
         vm.stopBroadcast();
+
+        return address(newImpl);
     }
 
     function getUpgradeCalldata() public returns (bytes memory) {

--- a/fault-proof/src/contract.rs
+++ b/fault-proof/src/contract.rs
@@ -101,6 +101,15 @@ sol! {
         /// @notice Returns the challenger bond amount.
         function challengerBond() external view returns (uint256 challengerBond_);
 
+        /// @notice Returns the aggregation verification key.
+        function aggregationVkey() external view returns (bytes32 aggregationVkey_);
+
+        /// @notice Returns the range verification key commitment.
+        function rangeVkeyCommitment() external view returns (bytes32 rangeVkeyCommitment_);
+
+        /// @notice Returns the rollup config hash.
+        function rollupConfigHash() external view returns (bytes32 rollupConfigHash_);
+
         /// @notice Claim the credit belonging to the recipient address.
         function claimCredit(address _recipient) external;
 

--- a/fault-proof/src/lib.rs
+++ b/fault-proof/src/lib.rs
@@ -106,6 +106,13 @@ pub trait FactoryTrait<P>
 where
     P: Provider + Clone,
 {
+    /// Returns the game implementation for the given game type.
+    /// Errors if the game type is not registered (zero address).
+    async fn game_impl(
+        &self,
+        game_type: u32,
+    ) -> Result<OPSuccinctFaultDisputeGame::OPSuccinctFaultDisputeGameInstance<P>>;
+
     /// Fetches the bond required to create a game.
     async fn fetch_init_bond(&self, game_type: u32) -> Result<U256>;
 
@@ -135,6 +142,19 @@ impl<P> FactoryTrait<P> for DisputeGameFactoryInstance<P>
 where
     P: Provider + Clone,
 {
+    /// Returns the game implementation for the given game type.
+    /// Errors if the game type is not registered (zero address).
+    async fn game_impl(
+        &self,
+        game_type: u32,
+    ) -> Result<OPSuccinctFaultDisputeGame::OPSuccinctFaultDisputeGameInstance<P>> {
+        let game_impl_address = self.gameImpls(game_type).call().await?;
+        if game_impl_address == Address::ZERO {
+            bail!("Game type {game_type} is not registered in the factory");
+        }
+        Ok(OPSuccinctFaultDisputeGame::new(game_impl_address, self.provider().clone()))
+    }
+
     /// Fetches the bond required to create a game.
     async fn fetch_init_bond(&self, game_type: u32) -> Result<U256> {
         let init_bond = self.initBonds(game_type).call().await?;

--- a/fault-proof/src/proposer.rs
+++ b/fault-proof/src/proposer.rs
@@ -13,7 +13,7 @@ use alloy_provider::{Provider, ProviderBuilder, RootProvider};
 use alloy_sol_types::{SolEvent, SolValue};
 use anyhow::{bail, Context, Result};
 use futures::stream::{self, StreamExt, TryStreamExt};
-use op_succinct_client_utils::boot::BootInfoStruct;
+use op_succinct_client_utils::boot::{hash_rollup_config, BootInfoStruct};
 use op_succinct_elfs::AGGREGATION_ELF;
 use op_succinct_host_utils::{
     fetcher::OPSuccinctDataFetcher,
@@ -26,8 +26,8 @@ use op_succinct_host_utils::{
 use op_succinct_proof_utils::get_range_elf_embedded;
 use op_succinct_signer_utils::SignerLock;
 use sp1_sdk::{
-    NetworkProver, Prover, ProverClient, SP1ProofMode, SP1ProofWithPublicValues, SP1ProvingKey,
-    SP1Stdin, SP1VerifyingKey, SP1_CIRCUIT_VERSION,
+    HashableKey, NetworkProver, Prover, ProverClient, SP1ProofMode, SP1ProofWithPublicValues,
+    SP1ProvingKey, SP1Stdin, SP1VerifyingKey, SP1_CIRCUIT_VERSION,
 };
 use tokio::{sync::Mutex, time};
 
@@ -70,6 +70,63 @@ struct SP1Prover {
     agg_pk: Arc<SP1ProvingKey>,
 }
 
+/// Proposer identity information for version tracking and monitoring.
+/// This helps operators identify which ELF version is running and enables
+/// compatibility checks during hardfork transitions.
+#[derive(Clone, Debug)]
+pub struct ProposerIdentity {
+    /// Full version string with DA layer suffix (e.g., "3.4.1-celestia")
+    pub version: String,
+    /// Aggregation verification key hash
+    pub aggregation_vkey: B256,
+    /// Range verification key commitment
+    pub range_vkey_commitment: B256,
+    /// Rollup configuration hash
+    pub rollup_config_hash: B256,
+}
+
+impl ProposerIdentity {
+    /// Returns the DA layer based on compile-time feature flags.
+    fn detect_da_layer() -> &'static str {
+        #[cfg(feature = "celestia")]
+        return "celestia";
+        #[cfg(all(feature = "eigenda", not(feature = "celestia")))]
+        return "eigenda";
+        #[cfg(not(any(feature = "celestia", feature = "eigenda")))]
+        return "ethereum";
+    }
+
+    /// Creates a new ProposerIdentity from computed vkeys and rollup config hash.
+    pub fn new(
+        aggregation_vkey: B256,
+        range_vkey_commitment: B256,
+        rollup_config_hash: B256,
+    ) -> Self {
+        let pkg_version = env!("CARGO_PKG_VERSION");
+        let da_layer = Self::detect_da_layer();
+        let version = format!("{}-{}", pkg_version, da_layer);
+
+        Self { version, aggregation_vkey, range_vkey_commitment, rollup_config_hash }
+    }
+
+    /// Logs the proposer identity at startup.
+    pub fn log_startup_info(&self) {
+        tracing::info!(
+            version = %self.version,
+            aggregation_vkey = %format!("0x{}", hex::encode(&self.aggregation_vkey[..8])),
+            range_vkey_commitment = %format!("0x{}", hex::encode(&self.range_vkey_commitment[..8])),
+            rollup_config_hash = %format!("0x{}", hex::encode(&self.rollup_config_hash[..8])),
+            "Proposer initialized"
+        );
+        tracing::debug!(
+            aggregation_vkey_full = %format!("0x{}", hex::encode(self.aggregation_vkey)),
+            range_vkey_commitment_full = %format!("0x{}", hex::encode(self.range_vkey_commitment)),
+            rollup_config_hash_full = %format!("0x{}", hex::encode(self.rollup_config_hash)),
+            "Full identity values"
+        );
+    }
+}
+
 /// Represents a dispute game in the on-chain game DAG.
 ///
 /// Games form a directed acyclic graph where each game builds upon a parent game, extending the
@@ -86,6 +143,20 @@ pub struct Game {
     pub deadline: u64,
     pub should_attempt_to_resolve: bool,
     pub should_attempt_to_claim_bond: bool,
+    pub aggregation_vkey: B256,
+    pub range_vkey_commitment: B256,
+    pub rollup_config_hash: B256,
+}
+
+impl Game {
+    /// Returns true if this game's identity params match the proposer's (owned = can
+    /// prove/resolve/claim). Checks aggregation_vkey, range_vkey_commitment, and
+    /// rollup_config_hash.
+    pub fn is_owned(&self, identity: &ProposerIdentity) -> bool {
+        self.aggregation_vkey == identity.aggregation_vkey &&
+            self.range_vkey_commitment == identity.range_vkey_commitment &&
+            self.rollup_config_hash == identity.rollup_config_hash
+    }
 }
 
 /// Central cache of the proposer's view of dispute games.
@@ -155,6 +226,9 @@ where
     tasks: Arc<Mutex<TaskMap>>,
     next_task_id: Arc<AtomicU64>,
     state: Arc<Mutex<ProposerState>>,
+    /// Proposer identity with version and vkey information for monitoring and compatibility
+    /// checks.
+    pub identity: ProposerIdentity,
 }
 
 impl<P, H> OPSuccinctProposer<P, H>
@@ -179,7 +253,22 @@ where
             ProverClient::builder().network_for(network_mode).signer(network_signer).build(),
         );
         let (range_pk, range_vk) = network_prover.setup(get_range_elf_embedded());
-        let (agg_pk, _) = network_prover.setup(AGGREGATION_ELF);
+        let (agg_pk, agg_vk) = network_prover.setup(AGGREGATION_ELF);
+
+        // Compute vkey hashes for on-chain compatibility checks.
+        // These are compared against game contract immutable values to ensure proof compatibility.
+        let aggregation_vkey = B256::from(agg_vk.bytes32_raw());
+        let range_vkey_commitment = B256::from(range_vk.hash_bytes());
+
+        // Compute rollup config hash from the fetcher's chain config.
+        let rollup_config_hash = hash_rollup_config(
+            fetcher.rollup_config.as_ref().context("rollup_config required for identity")?,
+        );
+
+        // Create proposer identity for monitoring and version tracking.
+        let identity =
+            ProposerIdentity::new(aggregation_vkey, range_vkey_commitment, rollup_config_hash);
+        identity.log_startup_info();
 
         let l1_provider = ProviderBuilder::default().connect_http(config.l1_rpc.clone());
         let l2_provider = ProviderBuilder::default().connect_http(config.l2_rpc.clone());
@@ -209,6 +298,7 @@ where
             tasks: Arc::new(Mutex::new(HashMap::new())),
             next_task_id: Arc::new(AtomicU64::new(1)),
             state: Arc::new(Mutex::new(initial_state)),
+            identity,
         })
     }
 
@@ -441,6 +531,24 @@ where
             state.canonical_head_index = Some(canonical_head.index);
             state.canonical_head_l2_block = Some(canonical_head.l2_block);
         }
+    }
+
+    /// Returns true if on-chain vkeys match ours (safe to create games).
+    /// Checks all 3 identity fields: aggregation_vkey, range_vkey_commitment, rollup_config_hash.
+    async fn on_chain_vkeys_match(&self) -> Result<bool> {
+        let game_impl = self.factory.game_impl(self.config.game_type).await?;
+        let on_chain_agg = B256::from(game_impl.aggregationVkey().call().await?.0);
+        let on_chain_range = B256::from(game_impl.rangeVkeyCommitment().call().await?.0);
+        let on_chain_rollup_hash = B256::from(game_impl.rollupConfigHash().call().await?.0);
+
+        let matches = on_chain_agg == self.identity.aggregation_vkey &&
+            on_chain_range == self.identity.range_vkey_commitment &&
+            on_chain_rollup_hash == self.identity.rollup_config_hash;
+
+        if !matches {
+            tracing::info!("Proposer vkeys mismatch with on-chain vkeys - skipping game creation (hardfork detected)");
+        }
+        Ok(matches)
     }
 
     /// Proves a dispute game at the given address.
@@ -774,6 +882,8 @@ where
             state
                 .games
                 .values()
+                // Only resolve owned games (vkeys match).
+                .filter(|game| game.is_owned(&self.identity))
                 .filter(|game| game.should_attempt_to_resolve)
                 .cloned()
                 .collect::<Vec<_>>()
@@ -805,6 +915,8 @@ where
             state
                 .games
                 .values()
+                // Only claim bonds for owned games (vkeys match).
+                .filter(|game| game.is_owned(&self.identity))
                 .filter(|game| game.should_attempt_to_claim_bond)
                 .cloned()
                 .collect::<Vec<_>>()
@@ -913,6 +1025,10 @@ where
             return Ok(());
         }
 
+        let aggregation_vkey = B256::from(contract.aggregationVkey().call().await?.0);
+        let range_vkey_commitment = B256::from(contract.rangeVkeyCommitment().call().await?.0);
+        let rollup_config_hash = B256::from(contract.rollupConfigHash().call().await?.0);
+
         if parent_index != u32::MAX {
             let parent_idx = U256::from(parent_index);
             if !state.games.contains_key(&parent_idx) {
@@ -934,21 +1050,26 @@ where
             }
         }
 
-        state.games.insert(
+        let game = Game {
             index,
-            Game {
-                index,
-                address: game_address,
-                parent_index,
-                l2_block,
-                status,
-                proposal_status,
-                deadline,
-                should_attempt_to_resolve: false,
-                should_attempt_to_claim_bond: false,
-            },
-        );
+            address: game_address,
+            parent_index,
+            l2_block,
+            status,
+            proposal_status,
+            deadline,
+            should_attempt_to_resolve: false,
+            should_attempt_to_claim_bond: false,
+            aggregation_vkey,
+            range_vkey_commitment,
+            rollup_config_hash,
+        };
 
+        if !game.is_owned(&self.identity) {
+            tracing::info!(game_index = %index, "Discovered foreign game (proposer's identity params don't match on-chain params) - tracking for DAG but not proving/resolving/claiming");
+        }
+
+        state.games.insert(index, game);
         state.cursor = Some(index);
 
         Ok(())
@@ -1135,7 +1256,7 @@ where
             Err(e) => tracing::warn!("Failed to spawn game defense tasks: {:?}", e),
         }
 
-        // Spawn game resolution task
+        // Spawn game resolution task (only operates on owned games via is_owned() filter)
         if !self.has_active_task_of_type(&TaskInfo::GameResolution).await {
             if let Err(e) = self.spawn_game_resolution_task().await {
                 tracing::warn!("Failed to spawn game resolution task: {:?}", e);
@@ -1144,7 +1265,7 @@ where
             }
         }
 
-        // Spawn bond claim task
+        // Spawn bond claim task (only operates on owned games via is_owned() filter)
         if !self.has_active_task_of_type(&TaskInfo::BondClaim).await {
             if let Err(e) = self.spawn_bond_claim_task().await {
                 tracing::warn!("Failed to spawn bond claim task: {:?}", e);
@@ -1358,6 +1479,11 @@ where
             }
         }
 
+        // Skip creation if on-chain vkeys don't match (hardfork detected).
+        if !self.on_chain_vkeys_match().await? {
+            return Ok((false, U256::ZERO));
+        }
+
         let Some(canonical_head_l2_block) = self.state.lock().await.canonical_head_l2_block else {
             tracing::info!("No canonical head; skipping game creation");
             return Ok((false, U256::ZERO));
@@ -1440,8 +1566,13 @@ where
         })
     }
 
-    /// Spawn a game proving task for a specific game
+    /// Spawn a game proving task. Skips if deadline passed or vkeys don't match.
     async fn spawn_game_proving_task(&self, game_address: Address, is_defense: bool) -> Result<()> {
+        // Skip if game is not owned
+        if self.should_skip_proving(game_address).await? {
+            return Ok(());
+        }
+
         let proposer: OPSuccinctProposer<P, H> = self.clone();
         let task_id = self.next_task_id.fetch_add(1, Ordering::Relaxed);
 
@@ -1514,6 +1645,33 @@ where
         let task_info = TaskInfo::GameProving { game_address, is_defense };
         self.tasks.lock().await.insert(task_id, (handle, task_info));
         Ok(())
+    }
+
+    /// Check if proving should be skipped for any reason.
+    ///
+    /// Returns `Ok(true)` if proving should be skipped:
+    /// - Game not found in cache
+    /// - Game not owned (vkeys don't match)
+    ///
+    /// Returns `Ok(false)` if proving should proceed.
+    async fn should_skip_proving(&self, game_address: Address) -> Result<bool> {
+        // Check ownership - only prove games we own
+        {
+            let state = self.state.lock().await;
+            let game = state.games.values().find(|g| g.address == game_address);
+
+            match game {
+                Some(game) if !game.is_owned(&self.identity) => {
+                    tracing::info!(?game_address, "Skipping foreign game (vkey mismatch)");
+                    Ok(true)
+                }
+                None => {
+                    tracing::warn!(?game_address, "Game not in cache, skipping");
+                    Ok(true)
+                }
+                _ => Ok(false),
+            }
+        }
     }
 
     /// Spawn a game resolution task

--- a/fault-proof/src/proposer.rs
+++ b/fault-proof/src/proposer.rs
@@ -1439,7 +1439,7 @@ where
 
                     // Spawn proving task
                     match self.spawn_game_proving_task(game_address, false).await {
-                        Ok(()) => {
+                        Ok(true) => {
                             tracing::info!(
                                 game_address = ?game_address,
                                 game_index = %index,
@@ -1448,6 +1448,7 @@ where
                             spawned_count += 1;
                             active_proving += 1;
                         }
+                        Ok(false) => {}
                         Err(e) => {
                             tracing::warn!(
                                 ?game_address,
@@ -1545,14 +1546,15 @@ where
                 continue;
             }
 
-            tracing::info!(
-                game_address = ?game_address,
-                game_index = %index,
-                "Spawning defense for challenged game"
-            );
-            self.spawn_game_proving_task(game_address, true).await?;
-            active_defense_tasks_count += 1;
-            tasks_spawned = true;
+            if self.spawn_game_proving_task(game_address, true).await? {
+                tracing::info!(
+                    game_address = ?game_address,
+                    game_index = %index,
+                    "Spawned defense for challenged game"
+                );
+                active_defense_tasks_count += 1;
+                tasks_spawned = true;
+            }
         }
 
         Ok(tasks_spawned)
@@ -1567,10 +1569,15 @@ where
     }
 
     /// Spawn a game proving task. Skips if deadline passed or vkeys don't match.
-    async fn spawn_game_proving_task(&self, game_address: Address, is_defense: bool) -> Result<()> {
+    /// Returns `Ok(true)` if spawned, `Ok(false)` if skipped.
+    async fn spawn_game_proving_task(
+        &self,
+        game_address: Address,
+        is_defense: bool,
+    ) -> Result<bool> {
         // Skip if game is not owned
         if self.should_skip_proving(game_address).await? {
-            return Ok(());
+            return Ok(false);
         }
 
         let proposer: OPSuccinctProposer<P, H> = self.clone();
@@ -1644,7 +1651,7 @@ where
 
         let task_info = TaskInfo::GameProving { game_address, is_defense };
         self.tasks.lock().await.insert(task_id, (handle, task_info));
-        Ok(())
+        Ok(true)
     }
 
     /// Check if proving should be skipped for any reason.

--- a/fault-proof/tests/common/constants.rs
+++ b/fault-proof/tests/common/constants.rs
@@ -1,6 +1,6 @@
 //! Shared constants for E2E tests.
 
-use alloy_primitives::{address, Address, B256, U256};
+use alloy_primitives::{address, Address, U256};
 
 // Anvil predefined accounts
 pub const ANVIL_ACCOUNT_0: Address = address!("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
@@ -32,11 +32,6 @@ pub const DISPUTE_GAME_FINALITY_DELAY_SECONDS: u64 = 60 * 60 * 24 * 7; // 7 days
 pub const MAX_CHALLENGE_DURATION: u64 = 60 * 60; // 1 hour
 pub const MAX_PROVE_DURATION: u64 = 60 * 60 * 12; // 12 hours
 pub const FALLBACK_TIMEOUT: U256 = U256::from_limbs([1209600, 0, 0, 0]); // 2 weeks
-
-// Configuration hashes for OPSuccinctFaultDisputeGame
-pub const ROLLUP_CONFIG_HASH: B256 = B256::ZERO; // Mock value for testing
-pub const AGGREGATION_VKEY: B256 = B256::ZERO; // Mock value for testing
-pub const RANGE_VKEY_COMMITMENT: B256 = B256::ZERO; // Mock value for testing
 
 // Test configuration for L2 block offset
 // This offset is subtracted from finalized L2 block to get the starting anchor block

--- a/fault-proof/tests/common/env.rs
+++ b/fault-proof/tests/common/env.rs
@@ -1,11 +1,15 @@
 //! Common test environment setup utilities.
-use alloy_primitives::Address;
+use alloy_primitives::{hex, Address, B256};
 use alloy_transport_http::reqwest::Url;
-use anyhow::Result;
+use anyhow::{Context, Result};
+use op_succinct_client_utils::{boot::hash_rollup_config, types::u32_to_u8};
+use op_succinct_elfs::AGGREGATION_ELF;
 use op_succinct_host_utils::{
-    fetcher::{get_rpcs_from_env, RPCConfig},
+    fetcher::{get_rpcs_from_env, OPSuccinctDataFetcher, RPCConfig},
     OP_SUCCINCT_FAULT_DISPUTE_GAME_CONFIG_PATH,
 };
+use op_succinct_proof_utils::get_range_elf_embedded;
+use sp1_sdk::{HashableKey, Prover, ProverClient};
 use tracing::info;
 
 use fault_proof::config::FaultDisputeGameConfig;
@@ -37,11 +41,35 @@ impl Drop for TestEnvironment {
     }
 }
 
+/// Compute vkeys from ELF programs.
+/// Returns (aggregation_vkey, range_vkey_commitment) as B256 values.
+/// Uses the same computation as `proposer.rs` and `config_common.rs`.
+pub fn compute_vkeys() -> (B256, B256) {
+    let prover = ProverClient::builder().cpu().build();
+
+    let (_, agg_vk) = prover.setup(AGGREGATION_ELF);
+    let aggregation_vkey = {
+        let hex_str = agg_vk.bytes32();
+        B256::from_slice(&hex::decode(hex_str.trim_start_matches("0x")).unwrap())
+    };
+
+    let (_, range_vk) = prover.setup(get_range_elf_embedded());
+    let range_vkey_commitment = B256::from(u32_to_u8(range_vk.vk.hash_u32()));
+
+    (aggregation_vkey, range_vkey_commitment)
+}
+
 /// The test configuration, used for integration tests.
-pub fn test_config(starting_l2_block_number: u64, starting_root: String) -> FaultDisputeGameConfig {
+pub fn test_config(
+    starting_l2_block_number: u64,
+    starting_root: String,
+    aggregation_vkey: B256,
+    range_vkey_commitment: B256,
+    rollup_config_hash: B256,
+) -> FaultDisputeGameConfig {
     FaultDisputeGameConfig {
         activate_contracts: false,
-        aggregation_vkey: AGGREGATION_VKEY.to_string(),
+        aggregation_vkey: aggregation_vkey.to_string(),
         anchor_state_registry_address: Address::ZERO.to_string(),
         celo_superchain_config_address: Address::ZERO.to_string(),
         challenger_addresses: vec![CHALLENGER_ADDRESS.to_string()],
@@ -57,8 +85,8 @@ pub fn test_config(starting_l2_block_number: u64, starting_root: String) -> Faul
         optimism_portal2_address: Address::ZERO.to_string(),
         permissionless_mode: false,
         proposer_addresses: vec![PROPOSER_ADDRESS.to_string()],
-        range_vkey_commitment: RANGE_VKEY_COMMITMENT.to_string(),
-        rollup_config_hash: ROLLUP_CONFIG_HASH.to_string(),
+        range_vkey_commitment: range_vkey_commitment.to_string(),
+        rollup_config_hash: rollup_config_hash.to_string(),
         starting_l2_block_number,
         starting_root,
         use_sp1_mock_verifier: true,
@@ -79,15 +107,30 @@ impl TestEnvironment {
 
     /// Create a new test environment with common setup
     pub async fn setup() -> Result<Self> {
+        // Compute vkeys from ELFs - these will match the proposer's computed vkeys
+        let (aggregation_vkey, range_vkey_commitment) = compute_vkeys();
+
         // Get environment variables
         let mut rpc_config = get_rpcs_from_env();
+
+        let fetcher = OPSuccinctDataFetcher::new_with_rollup_config().await?;
+
+        // Compute rollup_config_hash from fetcher's chain config - matches proposer's computation
+        let rollup_config_hash = hash_rollup_config(
+            fetcher.rollup_config.as_ref().context("rollup_config required for test setup")?,
+        );
 
         // Setup fresh Anvil chain
         let anvil = setup_anvil_chain().await?;
 
         // Put the test config into ../contracts/opsuccinctfdgconfig.json
-        let test_config: FaultDisputeGameConfig =
-            test_config(anvil.starting_l2_block_number, anvil.starting_root.clone());
+        let test_config: FaultDisputeGameConfig = test_config(
+            anvil.starting_l2_block_number,
+            anvil.starting_root.clone(),
+            aggregation_vkey,
+            range_vkey_commitment,
+            rollup_config_hash,
+        );
         let json = serde_json::to_string_pretty(&test_config)?;
         std::fs::write(OP_SUCCINCT_FAULT_DISPUTE_GAME_CONFIG_PATH.clone(), json)?;
 

--- a/justfile
+++ b/justfile
@@ -175,6 +175,38 @@ deploy-mock-verifier env_file=".env":
     --broadcast \
     $VERIFY
 
+# Upgrade the game implementation contract (for hardfork/upgrade)
+# This script deploys a new OPSuccinctFaultDisputeGame implementation and sets it in the factory.
+# Required env vars: FACTORY_ADDRESS, GAME_TYPE, VERIFIER_ADDRESS, ANCHOR_STATE_REGISTRY, ACCESS_MANAGER,
+#                    AGGREGATION_VKEY, RANGE_VKEY_COMMITMENT, ROLLUP_CONFIG_HASH,
+#                    MAX_CHALLENGE_DURATION, MAX_PROVE_DURATION, CHALLENGER_BOND_WEI
+upgrade-game-impl env_file=".env":
+    #!/usr/bin/env bash
+    set -aeo pipefail
+
+    source {{env_file}}
+
+    if [ -z "$L1_RPC" ]; then
+        echo "L1_RPC not set in {{env_file}}"
+        exit 1
+    fi
+
+    if [ -z "$PRIVATE_KEY" ]; then
+        echo "PRIVATE_KEY not set in {{env_file}}"
+        exit 1
+    fi
+
+    cd contracts
+
+    echo "Upgrading game implementation..."
+    forge script script/fp/UpgradeOPSuccinctFDG.s.sol \
+        --rpc-url "$L1_RPC" \
+        --private-key "$PRIVATE_KEY" \
+        --broadcast \
+        --slow
+
+    echo "Game implementation upgrade complete!"
+
 # Deploy the OPSuccinct L2 Output Oracle
 deploy-oracle env_file=".env" *features='':
     #!/usr/bin/env bash


### PR DESCRIPTION
To support the proposer's hardfork transition, the current `celo/v1.0.2` based proposer should have its proposer identity and handle games based on that identity, so it does not interact with games created after Jovian hardfork. 

This PR adds that functionality to the `celo/v1.0.2` proposer. Each cherry-picked commit includes the resolved conflicts in itself. I created the base branch from `celo/v1.0.2` tag and it will be the target branch for the old proposer binary.

Related to https://github.com/celo-org/op-succinct/issues/92

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches proposer scheduling logic for creating/proving/resolving/claiming and introduces new on-chain reads; mistakes could stall proposals or leave bonds unclaimed during/after upgrades.
> 
> **Overview**
> Adds **hardfork-aware proposer identity** (aggregation vkey, range vkey commitment, rollup config hash + version string) computed at startup, logged for monitoring, and cached per-game so the proposer can distinguish *owned* vs *foreign* games.
> 
> Game creation is now gated by `on_chain_vkeys_match()` (reads the current factory implementation’s identity params and skips proposing on mismatch), and proving/resolution/bond-claim flows now operate only on owned games (foreign games remain tracked only for canonical head/DAG calculations). Supporting changes add contract bindings for the new immutable getters, a `FactoryTrait::game_impl()` helper, test env updates to compute matching vkeys/config hashes, plus docs and a `just upgrade-game-impl` workflow (with the forge upgrade script returning the new impl address).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b4824faa0af6fb055bcc45365f2810083d989696. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->