### PR TITLE
Backport upstream fix for v1.0.0 games backward compatability

### DIFF
--- a/.github/workflows/cargo-tests.yml
+++ b/.github/workflows/cargo-tests.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Install SP1 toolchain
       run: |
           curl -L https://sp1.succinct.xyz | bash
-          ~/.sp1/bin/sp1up 
+          ~/.sp1/bin/sp1up -v 5.2.4
           ~/.sp1/bin/cargo-prove prove --version
           source ~/.bashrc
 

--- a/.github/workflows/cycle-count-diff-eigenda.yml
+++ b/.github/workflows/cycle-count-diff-eigenda.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install SP1 toolchain
         run: |
           curl -L https://sp1.succinct.xyz | bash
-          ~/.sp1/bin/sp1up
+          ~/.sp1/bin/sp1up -v 5.2.4
           ~/.sp1/bin/cargo-prove prove --version
           source ~/.bashrc
 

--- a/.github/workflows/cycle-count-diff.yml
+++ b/.github/workflows/cycle-count-diff.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install SP1 toolchain
         run: |
           curl -L https://sp1.succinct.xyz | bash
-          ~/.sp1/bin/sp1up 
+          ~/.sp1/bin/sp1up -v 5.2.4
           ~/.sp1/bin/cargo-prove prove --version
           source ~/.bashrc
 

--- a/.github/workflows/elf.yml
+++ b/.github/workflows/elf.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install SP1 toolchain
         run: |
           curl -L https://sp1.succinct.xyz | bash
-          ~/.sp1/bin/sp1up
+          ~/.sp1/bin/sp1up -v 5.2.4
           ~/.sp1/bin/cargo-prove prove --version
           source ~/.bashrc
       - name: Setup Docker Buildx

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Install SP1 toolchain
         run: |
           curl -L https://sp1.succinct.xyz | bash
-          ~/.sp1/bin/sp1up 
+          ~/.sp1/bin/sp1up -v 5.2.4
           ~/.sp1/bin/cargo-prove prove --version
           source ~/.bashrc
 

--- a/book/advanced/verify-binaries.md
+++ b/book/advanced/verify-binaries.md
@@ -16,7 +16,7 @@ Anything that changes these programs requires reproducing the binaries. This inc
 Ensure you have the [`cargo prove`](https://docs.succinct.xyz/docs/sp1/getting-started/install#option-1-prebuilt-binaries-recommended) CLI tool installed and have the latest version of the toolchain by running:
 
 ```bash
-sp1up
+sp1up -v 5.2.4
 ```
 
 and

--- a/fault-proof/Dockerfile.challenger
+++ b/fault-proof/Dockerfile.challenger
@@ -22,7 +22,7 @@ RUN rustup install stable && rustup default stable
 
 # Install SP1
 RUN curl -L https://sp1.succinct.xyz | bash && \
-    ~/.sp1/bin/sp1up && \
+    ~/.sp1/bin/sp1up -v 5.2.4 && \
     ~/.sp1/bin/cargo-prove prove --version
 
 # Build stage

--- a/fault-proof/Dockerfile.challenger.celo
+++ b/fault-proof/Dockerfile.challenger.celo
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install SP1
 RUN curl -L https://sp1.succinct.xyz | bash && \
-    ~/.sp1/bin/sp1up && \
+    ~/.sp1/bin/sp1up -v 5.2.4 && \
     ~/.sp1/bin/cargo-prove prove --version
 
 

--- a/fault-proof/Dockerfile.proposer
+++ b/fault-proof/Dockerfile.proposer
@@ -22,7 +22,7 @@ RUN rustup install stable && rustup default stable
 
 # Install SP1
 RUN curl -L https://sp1.succinct.xyz | bash && \
-    ~/.sp1/bin/sp1up && \
+    ~/.sp1/bin/sp1up -v 5.2.4 && \
     ~/.sp1/bin/cargo-prove prove --version
 
 # Build stage

--- a/fault-proof/Dockerfile.proposer.celestia
+++ b/fault-proof/Dockerfile.proposer.celestia
@@ -22,7 +22,7 @@ RUN rustup install stable && rustup default stable
 
 # Install SP1
 RUN curl -L https://sp1.succinct.xyz | bash && \
-    ~/.sp1/bin/sp1up && \
+    ~/.sp1/bin/sp1up -v 5.2.4 && \
     ~/.sp1/bin/cargo-prove prove --version
 
 # Build stage

--- a/fault-proof/Dockerfile.proposer.celo
+++ b/fault-proof/Dockerfile.proposer.celo
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install SP1
 RUN curl -L https://sp1.succinct.xyz | bash && \
-    ~/.sp1/bin/sp1up && \
+    ~/.sp1/bin/sp1up -v 5.2.4 && \
     ~/.sp1/bin/cargo-prove prove --version
 
 

--- a/fault-proof/Dockerfile.proposer.eigenda
+++ b/fault-proof/Dockerfile.proposer.eigenda
@@ -22,7 +22,7 @@ RUN rustup install stable && rustup default stable
 
 # Install SP1
 RUN curl -L https://sp1.succinct.xyz | bash && \
-    ~/.sp1/bin/sp1up && \
+    ~/.sp1/bin/sp1up -v 5.2.4 && \
     ~/.sp1/bin/cargo-prove prove --version
 
 # Build stage

--- a/fault-proof/src/challenger.rs
+++ b/fault-proof/src/challenger.rs
@@ -354,7 +354,7 @@ where
             return Ok(());
         }
 
-        let l2_block_number = contract.l2SequenceNumber().call().await?;
+        let l2_block_number = contract.l2BlockNumber().call().await?;
         let computed_output_root =
             self.l2_provider.compute_output_root_at_block(l2_block_number).await?;
         let output_root = contract.rootClaim().call().await?;

--- a/fault-proof/src/contract.rs
+++ b/fault-proof/src/contract.rs
@@ -63,6 +63,10 @@ sol! {
         /// @notice The L2 sequence number (block number) for which this game is proposing an output root.
         function l2SequenceNumber() public pure returns (uint256 l2SequenceNumber_);
 
+        /// @notice The L2 block number for which this game is proposing an output root.
+        /// @dev Alias for l2SequenceNumber() for backward compatibility.
+        function l2BlockNumber() public pure returns (uint256 l2BlockNumber_);
+
         /// @notice Only the starting block number of the game.
         function startingBlockNumber() external view returns (uint256 startingBlockNumber_);
 

--- a/fault-proof/src/proposer.rs
+++ b/fault-proof/src/proposer.rs
@@ -1382,7 +1382,7 @@ where
 
         let contract = OPSuccinctFaultDisputeGame::new(game_address, self.l1_provider.clone());
 
-        let l2_block = contract.l2SequenceNumber().call().await?;
+        let l2_block = contract.l2BlockNumber().call().await?;
         let output_root = self.l2_provider.compute_output_root_at_block(l2_block).await?;
         let claim = contract.rootClaim().call().await?;
         let was_respected = contract.wasRespectedGameTypeWhenCreated().call().await?;
@@ -2034,7 +2034,7 @@ where
         // Get the game block number to include in logs
         let game = OPSuccinctFaultDisputeGame::new(game_address, self.l1_provider.clone());
         let starting_l2_block_number = game.startingBlockNumber().call().await?;
-        let l2_block_number = game.l2SequenceNumber().call().await?;
+        let l2_block_number = game.l2BlockNumber().call().await?;
         let start_block = starting_l2_block_number.to::<u64>();
         let end_block = l2_block_number.to::<u64>();
 

--- a/fault-proof/tests/common/monitor.rs
+++ b/fault-proof/tests/common/monitor.rs
@@ -131,7 +131,7 @@ pub async fn wait_and_track_games<P: Provider>(
                         OPSuccinctFaultDisputeGame::new(game_info.proxy_, factory.provider());
 
                     // Get game details
-                    let l2_block_number = game.l2SequenceNumber().call().await?;
+                    let l2_block_number = game.l2BlockNumber().call().await?;
                     let parent_index = game.claimData().call().await?.parentIndex;
 
                     let tracked = TrackedGame {

--- a/scripts/utils/Dockerfile.game-monitor
+++ b/scripts/utils/Dockerfile.game-monitor
@@ -22,7 +22,7 @@ RUN rustup install stable && rustup default stable
 
 # Install SP1
 RUN curl -L https://sp1.succinct.xyz | bash && \
-    ~/.sp1/bin/sp1up -v v5.2.2 && \
+    ~/.sp1/bin/sp1up -v 5.2.4 && \
     ~/.sp1/bin/cargo-prove prove --version
 
 # Copy toolchain file

--- a/scripts/utils/Dockerfile.parallel-cost-estimator
+++ b/scripts/utils/Dockerfile.parallel-cost-estimator
@@ -27,7 +27,7 @@ RUN rustup show && \
 
 # Install SP1
 RUN curl -L https://sp1.succinct.xyz | bash && \
-    ~/.sp1/bin/sp1up && \
+    ~/.sp1/bin/sp1up -v 5.2.4 && \
     ~/.sp1/bin/cargo-prove prove --version
 ENV PATH=/root/.sp1/bin:$PATH
 

--- a/validity/Dockerfile
+++ b/validity/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /build
 
 # Install SP1
 RUN curl -L https://sp1.succinct.xyz | bash && \
-    ~/.sp1/bin/sp1up && \
+    ~/.sp1/bin/sp1up -v 5.2.4 && \
     ~/.sp1/bin/cargo-prove prove --version
 
 # Copy only what's needed for the build
@@ -47,7 +47,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install SP1
 RUN curl -L https://sp1.succinct.xyz | bash && \
-    ~/.sp1/bin/sp1up && \
+    ~/.sp1/bin/sp1up -v 5.2.4 && \
     ~/.sp1/bin/cargo-prove prove --version
 
 # Copy only the built binaries from builder

--- a/validity/Dockerfile.celestia
+++ b/validity/Dockerfile.celestia
@@ -15,7 +15,7 @@ WORKDIR /build
 
 # Install SP1
 RUN curl -L https://sp1.succinct.xyz | bash && \
-    ~/.sp1/bin/sp1up && \
+    ~/.sp1/bin/sp1up -v 5.2.4 && \
     ~/.sp1/bin/cargo-prove prove --version
 
 # Copy only what's needed for the build
@@ -46,7 +46,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install SP1
 RUN curl -L https://sp1.succinct.xyz | bash && \
-    ~/.sp1/bin/sp1up && \
+    ~/.sp1/bin/sp1up -v 5.2.4 && \
     ~/.sp1/bin/cargo-prove prove --version
 
 # Copy only the built binaries from builder

--- a/validity/Dockerfile.eigenda
+++ b/validity/Dockerfile.eigenda
@@ -15,7 +15,7 @@ WORKDIR /build
 
 # Install SP1
 RUN curl -L https://sp1.succinct.xyz | bash && \
-    ~/.sp1/bin/sp1up && \
+    ~/.sp1/bin/sp1up -v 5.2.4 && \
     ~/.sp1/bin/cargo-prove prove --version
 
 # Copy only what's needed for the build
@@ -49,7 +49,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install SP1
 RUN curl -L https://sp1.succinct.xyz | bash && \
-    ~/.sp1/bin/sp1up && \
+    ~/.sp1/bin/sp1up -v 5.2.4 && \
     ~/.sp1/bin/cargo-prove prove --version
 
 # Copy only the built binaries from builder


### PR DESCRIPTION
## Summary

- **Backward compatibility**: Use `l2BlockNumber()` instead of `l2SequenceNumber()` so the proposer works with v1.0.0 dispute games (where only `l2BlockNumber()` exists) during the upgrade of `OPSuccinctFaultDisputeGame` v1.0.0 → v2.0.0.
- **CI**: Pin `sp1up` to v5.2.4 everywhere. SP1 v6 (rv64) was released and `sp1up` now defaults to v6; this repo stays on v5.2.4 (as in Cargo.toml and justfile).

## Related

- Incorporates fix from #807 (backward compat).