### PR TITLE
Use rollup config from celo-registry prior to the one from node RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,7 +146,7 @@ dependencies = [
 [[package]]
 name = "alloy-celo-evm"
 version = "0.1.0"
-source = "git+https://github.com/celo-org/celo-kona?rev=5a8b83b#5a8b83b5c97f407c8bcf0d2d1e4511c639427292"
+source = "git+https://github.com/celo-org/celo-kona?rev=c90cbe8#c90cbe8e04c5d50138f62b417d58b53ecd8a08e8"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -2909,7 +2909,7 @@ dependencies = [
 [[package]]
 name = "celo-alloy-consensus"
 version = "0.1.0"
-source = "git+https://github.com/celo-org/celo-kona?rev=5a8b83b#5a8b83b5c97f407c8bcf0d2d1e4511c639427292"
+source = "git+https://github.com/celo-org/celo-kona?rev=c90cbe8#c90cbe8e04c5d50138f62b417d58b53ecd8a08e8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2925,7 +2925,7 @@ dependencies = [
 [[package]]
 name = "celo-alloy-network"
 version = "0.1.0"
-source = "git+https://github.com/celo-org/celo-kona?rev=5a8b83b#5a8b83b5c97f407c8bcf0d2d1e4511c639427292"
+source = "git+https://github.com/celo-org/celo-kona?rev=c90cbe8#c90cbe8e04c5d50138f62b417d58b53ecd8a08e8"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -2939,7 +2939,7 @@ dependencies = [
 [[package]]
 name = "celo-alloy-rpc-types"
 version = "0.1.0"
-source = "git+https://github.com/celo-org/celo-kona?rev=5a8b83b#5a8b83b5c97f407c8bcf0d2d1e4511c639427292"
+source = "git+https://github.com/celo-org/celo-kona?rev=c90cbe8#c90cbe8e04c5d50138f62b417d58b53ecd8a08e8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2958,7 +2958,7 @@ dependencies = [
 [[package]]
 name = "celo-alloy-rpc-types-engine"
 version = "0.1.0"
-source = "git+https://github.com/celo-org/celo-kona?rev=5a8b83b#5a8b83b5c97f407c8bcf0d2d1e4511c639427292"
+source = "git+https://github.com/celo-org/celo-kona?rev=c90cbe8#c90cbe8e04c5d50138f62b417d58b53ecd8a08e8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2974,7 +2974,7 @@ dependencies = [
 [[package]]
 name = "celo-client"
 version = "0.1.0"
-source = "git+https://github.com/celo-org/celo-kona?rev=5a8b83b#5a8b83b5c97f407c8bcf0d2d1e4511c639427292"
+source = "git+https://github.com/celo-org/celo-kona?rev=c90cbe8#c90cbe8e04c5d50138f62b417d58b53ecd8a08e8"
 dependencies = [
  "alloy-celo-evm",
  "alloy-consensus",
@@ -2999,7 +2999,7 @@ dependencies = [
 [[package]]
 name = "celo-driver"
 version = "0.1.0"
-source = "git+https://github.com/celo-org/celo-kona?rev=5a8b83b#5a8b83b5c97f407c8bcf0d2d1e4511c639427292"
+source = "git+https://github.com/celo-org/celo-kona?rev=c90cbe8#c90cbe8e04c5d50138f62b417d58b53ecd8a08e8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -3020,7 +3020,7 @@ dependencies = [
 [[package]]
 name = "celo-executor"
 version = "0.1.0"
-source = "git+https://github.com/celo-org/celo-kona?rev=5a8b83b#5a8b83b5c97f407c8bcf0d2d1e4511c639427292"
+source = "git+https://github.com/celo-org/celo-kona?rev=c90cbe8#c90cbe8e04c5d50138f62b417d58b53ecd8a08e8"
 dependencies = [
  "alloy-celo-evm",
  "alloy-consensus",
@@ -3048,7 +3048,7 @@ dependencies = [
 [[package]]
 name = "celo-genesis"
 version = "0.1.0"
-source = "git+https://github.com/celo-org/celo-kona?rev=5a8b83b#5a8b83b5c97f407c8bcf0d2d1e4511c639427292"
+source = "git+https://github.com/celo-org/celo-kona?rev=c90cbe8#c90cbe8e04c5d50138f62b417d58b53ecd8a08e8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3068,7 +3068,7 @@ dependencies = [
 [[package]]
 name = "celo-host"
 version = "0.1.0"
-source = "git+https://github.com/celo-org/celo-kona?rev=5a8b83b#5a8b83b5c97f407c8bcf0d2d1e4511c639427292"
+source = "git+https://github.com/celo-org/celo-kona?rev=c90cbe8#c90cbe8e04c5d50138f62b417d58b53ecd8a08e8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3105,7 +3105,7 @@ dependencies = [
 [[package]]
 name = "celo-proof"
 version = "0.1.0"
-source = "git+https://github.com/celo-org/celo-kona?rev=5a8b83b#5a8b83b5c97f407c8bcf0d2d1e4511c639427292"
+source = "git+https://github.com/celo-org/celo-kona?rev=c90cbe8#c90cbe8e04c5d50138f62b417d58b53ecd8a08e8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3140,7 +3140,7 @@ dependencies = [
 [[package]]
 name = "celo-protocol"
 version = "0.1.0"
-source = "git+https://github.com/celo-org/celo-kona?rev=5a8b83b#5a8b83b5c97f407c8bcf0d2d1e4511c639427292"
+source = "git+https://github.com/celo-org/celo-kona?rev=c90cbe8#c90cbe8e04c5d50138f62b417d58b53ecd8a08e8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3169,7 +3169,7 @@ dependencies = [
 [[package]]
 name = "celo-registry"
 version = "0.1.0"
-source = "git+https://github.com/celo-org/celo-kona?rev=5a8b83b#5a8b83b5c97f407c8bcf0d2d1e4511c639427292"
+source = "git+https://github.com/celo-org/celo-kona?rev=c90cbe8#c90cbe8e04c5d50138f62b417d58b53ecd8a08e8"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -3184,7 +3184,7 @@ dependencies = [
 [[package]]
 name = "celo-revm"
 version = "0.1.0"
-source = "git+https://github.com/celo-org/celo-kona?rev=5a8b83b#5a8b83b5c97f407c8bcf0d2d1e4511c639427292"
+source = "git+https://github.com/celo-org/celo-kona?rev=c90cbe8#c90cbe8e04c5d50138f62b417d58b53ecd8a08e8"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -9260,6 +9260,7 @@ dependencies = [
  "celo-host",
  "celo-proof",
  "celo-protocol",
+ "celo-registry",
  "cfg-if",
  "futures",
  "hana-host",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,11 +97,12 @@ kona-genesis = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.1.
 
 # TODO: replace commit hash with tag when available
 # celo-kona
-celo-driver = { git = "https://github.com/celo-org/celo-kona", rev = "5a8b83b" }
-celo-proof = { git = "https://github.com/celo-org/celo-kona", rev = "5a8b83b" }
-celo-host = { git = "https://github.com/celo-org/celo-kona", rev = "5a8b83b" }
-celo-protocol = { git = "https://github.com/celo-org/celo-kona", rev = "5a8b83b", default-features = false }
-celo-genesis = { git = "https://github.com/celo-org/celo-kona", rev = "5a8b83b", default-features = false }
+celo-driver = { git = "https://github.com/celo-org/celo-kona", rev = "c90cbe8" }
+celo-proof = { git = "https://github.com/celo-org/celo-kona", rev = "c90cbe8" }
+celo-host = { git = "https://github.com/celo-org/celo-kona", rev = "c90cbe8" }
+celo-protocol = { git = "https://github.com/celo-org/celo-kona", rev = "c90cbe8", default-features = false }
+celo-genesis = { git = "https://github.com/celo-org/celo-kona", rev = "c90cbe8", default-features = false }
+celo-registry = { git = "https://github.com/celo-org/celo-kona", rev = "c90cbe8", default-features = false }
 
 # hana
 hana-blobstream = { git = "https://github.com/celestiaorg/hana", rev = "1d272dd83263dbcc2ad97daaac84b2e578a0b288" }
@@ -188,10 +189,10 @@ op-alloy-rpc-types-engine = { version = "0.22.0", default-features = false }
 op-alloy-network = { version = "0.22.0", default-features = false }
 
 # Celo Alloy
-celo-alloy-consensus = { git = "https://github.com/celo-org/celo-kona", rev = "5a8b83b", default-features = false }
-celo-alloy-rpc-types = { git = "https://github.com/celo-org/celo-kona", rev = "5a8b83b", default-features = false }
-celo-alloy-rpc-types-engine = { git = "https://github.com/celo-org/celo-kona", rev = "5a8b83b", default-features = false }
-celo-alloy-network = { git = "https://github.com/celo-org/celo-kona", rev = "5a8b83b", default-features = false }
+celo-alloy-consensus = { git = "https://github.com/celo-org/celo-kona", rev = "c90cbe8", default-features = false }
+celo-alloy-rpc-types = { git = "https://github.com/celo-org/celo-kona", rev = "c90cbe8", default-features = false }
+celo-alloy-rpc-types-engine = { git = "https://github.com/celo-org/celo-kona", rev = "c90cbe8", default-features = false }
+celo-alloy-network = { git = "https://github.com/celo-org/celo-kona", rev = "c90cbe8", default-features = false }
 
 # Execution
 alloy-evm = { version = "0.23.1", default-features = false }
@@ -204,7 +205,7 @@ revm-precompile = { version = "29.0.1", default-features = false }
 op-revm = { version = "12.0.1", default-features = false }
 
 # Celo Execution
-alloy-celo-evm = { git = "https://github.com/celo-org/celo-kona", rev = "5a8b83b", default-features = false }
+alloy-celo-evm = { git = "https://github.com/celo-org/celo-kona", rev = "c90cbe8", default-features = false }
 
 # SP1
 sp1-sdk = { version = "=5.2.2", default-features = false, features = ["network"] }

--- a/utils/host/Cargo.toml
+++ b/utils/host/Cargo.toml
@@ -40,6 +40,7 @@ celo-host.workspace = true
 celo-protocol.workspace = true
 celo-genesis.workspace = true
 celo-proof.workspace = true
+celo-registry.workspace = true
 
 # hana
 hana-host.workspace = true

--- a/utils/host/src/fetcher.rs
+++ b/utils/host/src/fetcher.rs
@@ -18,12 +18,13 @@ use celo_alloy_consensus::CeloBlock;
 use celo_alloy_network::Celo;
 use celo_genesis::CeloRollupConfig;
 use celo_protocol::CeloL2BlockInfo;
+use celo_registry::ROLLUP_CONFIGS;
 use futures::{stream, StreamExt};
 use kona_host::single::SingleChainHost;
 use kona_registry::L1_CONFIGS;
 use kona_rpc::{OutputResponse, SafeHeadResponse};
 use op_alloy_network::{primitives::HeaderResponse, BlockResponse, Network};
-use op_succinct_client_utils::boot::BootInfoStruct;
+use op_succinct_client_utils::boot::{hash_rollup_config, BootInfoStruct};
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -313,8 +314,55 @@ impl OPSuccinctDataFetcher {
     async fn fetch_and_save_rollup_config(
         rpc_config: &RPCConfig,
     ) -> Result<(CeloRollupConfig, PathBuf)> {
-        let rollup_config: CeloRollupConfig =
-            Self::fetch_rpc_data(&rpc_config.l2_node_rpc, "optimism_rollupConfig", vec![]).await?;
+        // Fetch chain ID to look up registry config
+        let chain_id: String =
+            Self::fetch_rpc_data(&rpc_config.l2_rpc, "eth_chainId", vec![]).await?;
+        let chain_id: u64 = chain_id.parse::<U64>().unwrap().to();
+
+        // Fetch rollup config from node RPC (best-effort for hash comparison)
+        let node_rpc_config: Option<CeloRollupConfig> =
+            Self::fetch_rpc_data(&rpc_config.l2_node_rpc, "optimism_rollupConfig", vec![])
+                .await
+                .inspect(|_| {
+                    tracing::info!("Loaded L2 config for chain ID {} from node RPC", chain_id);
+                })
+                .map_err(|e| {
+                    tracing::warn!(
+                        "Failed to fetch rollup config from node RPC for chain ID {}: {:?}",
+                        chain_id,
+                        e
+                    );
+                })
+                .ok();
+
+        // Try to fetch rollup config from celo-registry; if found, compare hashes and use it
+        let rollup_config = if let Some(registry_config) = ROLLUP_CONFIGS.get(&chain_id) {
+            tracing::info!("Loaded L2 config for chain ID {} from registry", chain_id);
+            if let Some(ref node_config) = node_rpc_config {
+                let registry_hash = hash_rollup_config(registry_config);
+                let node_rpc_hash = hash_rollup_config(node_config);
+                if registry_hash != node_rpc_hash {
+                    tracing::warn!(
+                        "Rollup config hash mismatch for chain ID {}: registry hash = {:?}, node RPC hash = {:?}",
+                        chain_id,
+                        registry_hash,
+                        node_rpc_hash
+                    );
+                }
+            }
+            registry_config.clone()
+        } else {
+            tracing::warn!(
+                "No rollup config found in registry for chain ID {}. Falling back to node RPC config",
+                chain_id
+            );
+            node_rpc_config.ok_or_else(|| {
+                anyhow::anyhow!(
+                    "No rollup config available for chain ID {}: not in registry and node RPC fetch failed",
+                    chain_id
+                )
+            })?
+        };
 
         // Create configs directory if it doesn't exist
         let rollup_config_dir = PathBuf::from("configs/L2");


### PR DESCRIPTION
This is for the pre-hardfork succinct proposer, modifying `fetch_and_save_rollup_config` function (used by proposer, FDG params fetch command, etc.) to prioritize fetching the rollup config from celo-registry over the node RPC. The function should also compare the hash of both configs and log a warning if they do not match.

This version is paired with https://github.com/celo-org/celo-kona/pull/132. I confirmed that the computed `rollup_config_hash` for Celo Chaos, Celo Sepolia, Celo Mainnet is matched with the on-chain `rollup_config_hash`.

Related to https://github.com/celo-org/celo-blockchain-planning/issues/1351