### PR TITLE
Add l2SequenceNumber function for forward compatibility

### DIFF
--- a/contracts/src/fp/OPSuccinctFaultDisputeGame.sol
+++ b/contracts/src/fp/OPSuccinctFaultDisputeGame.sol
@@ -307,9 +307,15 @@ contract OPSuccinctFaultDisputeGame is Clone, ISemver, IDisputeGame {
             GameType.unwrap(ANCHOR_STATE_REGISTRY.respectedGameType()) == GameType.unwrap(GAME_TYPE);
     }
 
+    /// @notice The L2 sequence number (block number) for which this game is proposing an output root.
+    function l2SequenceNumber() public pure returns (uint256 l2SequenceNumber_) {
+        l2SequenceNumber_ = _getArgUint256(0x54);
+    }
+
     /// @notice The L2 block number for which this game is proposing an output root.
+    /// @dev Alias for l2SequenceNumber() for backward compatibility.
     function l2BlockNumber() public pure returns (uint256 l2BlockNumber_) {
-        l2BlockNumber_ = _getArgUint256(0x54);
+        l2BlockNumber_ = l2SequenceNumber();
     }
 
     /// @notice The parent index of the game.


### PR DESCRIPTION
This is for forward-compatible v1 `OPSuccinctFDG` contract to be compatible with v5 op-contracts (especially [`AnchorStateRegistry`](https://github.com/ethereum-optimism/optimism/blob/d09c836f818c73ae139f60b717654c4e53712743/packages/contracts-bedrock/src/dispute/AnchorStateRegistry.sol#L175)). We need to upgrade current `OPSuccintFDG` to this version at least 7 days prior to v5 op-contracts deployment, so that this version game is set to anchor state before the v5 upgrade.