### PR TITLE
Use celo-kona version with rollup-config for new Chaos deployment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,7 +146,7 @@ dependencies = [
 [[package]]
 name = "alloy-celo-evm"
 version = "0.1.0"
-source = "git+https://github.com/celo-org/celo-kona?rev=c90cbe8#c90cbe8e04c5d50138f62b417d58b53ecd8a08e8"
+source = "git+https://github.com/celo-org/celo-kona?rev=eb28668#eb28668b0b8173c4179a92621dbdbda80c9d05b0"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -2909,7 +2909,7 @@ dependencies = [
 [[package]]
 name = "celo-alloy-consensus"
 version = "0.1.0"
-source = "git+https://github.com/celo-org/celo-kona?rev=c90cbe8#c90cbe8e04c5d50138f62b417d58b53ecd8a08e8"
+source = "git+https://github.com/celo-org/celo-kona?rev=eb28668#eb28668b0b8173c4179a92621dbdbda80c9d05b0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2925,7 +2925,7 @@ dependencies = [
 [[package]]
 name = "celo-alloy-network"
 version = "0.1.0"
-source = "git+https://github.com/celo-org/celo-kona?rev=c90cbe8#c90cbe8e04c5d50138f62b417d58b53ecd8a08e8"
+source = "git+https://github.com/celo-org/celo-kona?rev=eb28668#eb28668b0b8173c4179a92621dbdbda80c9d05b0"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -2939,7 +2939,7 @@ dependencies = [
 [[package]]
 name = "celo-alloy-rpc-types"
 version = "0.1.0"
-source = "git+https://github.com/celo-org/celo-kona?rev=c90cbe8#c90cbe8e04c5d50138f62b417d58b53ecd8a08e8"
+source = "git+https://github.com/celo-org/celo-kona?rev=eb28668#eb28668b0b8173c4179a92621dbdbda80c9d05b0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2958,7 +2958,7 @@ dependencies = [
 [[package]]
 name = "celo-alloy-rpc-types-engine"
 version = "0.1.0"
-source = "git+https://github.com/celo-org/celo-kona?rev=c90cbe8#c90cbe8e04c5d50138f62b417d58b53ecd8a08e8"
+source = "git+https://github.com/celo-org/celo-kona?rev=eb28668#eb28668b0b8173c4179a92621dbdbda80c9d05b0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2974,7 +2974,7 @@ dependencies = [
 [[package]]
 name = "celo-client"
 version = "0.1.0"
-source = "git+https://github.com/celo-org/celo-kona?rev=c90cbe8#c90cbe8e04c5d50138f62b417d58b53ecd8a08e8"
+source = "git+https://github.com/celo-org/celo-kona?rev=eb28668#eb28668b0b8173c4179a92621dbdbda80c9d05b0"
 dependencies = [
  "alloy-celo-evm",
  "alloy-consensus",
@@ -2999,7 +2999,7 @@ dependencies = [
 [[package]]
 name = "celo-driver"
 version = "0.1.0"
-source = "git+https://github.com/celo-org/celo-kona?rev=c90cbe8#c90cbe8e04c5d50138f62b417d58b53ecd8a08e8"
+source = "git+https://github.com/celo-org/celo-kona?rev=eb28668#eb28668b0b8173c4179a92621dbdbda80c9d05b0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -3020,7 +3020,7 @@ dependencies = [
 [[package]]
 name = "celo-executor"
 version = "0.1.0"
-source = "git+https://github.com/celo-org/celo-kona?rev=c90cbe8#c90cbe8e04c5d50138f62b417d58b53ecd8a08e8"
+source = "git+https://github.com/celo-org/celo-kona?rev=eb28668#eb28668b0b8173c4179a92621dbdbda80c9d05b0"
 dependencies = [
  "alloy-celo-evm",
  "alloy-consensus",
@@ -3048,7 +3048,7 @@ dependencies = [
 [[package]]
 name = "celo-genesis"
 version = "0.1.0"
-source = "git+https://github.com/celo-org/celo-kona?rev=c90cbe8#c90cbe8e04c5d50138f62b417d58b53ecd8a08e8"
+source = "git+https://github.com/celo-org/celo-kona?rev=eb28668#eb28668b0b8173c4179a92621dbdbda80c9d05b0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3068,7 +3068,7 @@ dependencies = [
 [[package]]
 name = "celo-host"
 version = "0.1.0"
-source = "git+https://github.com/celo-org/celo-kona?rev=c90cbe8#c90cbe8e04c5d50138f62b417d58b53ecd8a08e8"
+source = "git+https://github.com/celo-org/celo-kona?rev=eb28668#eb28668b0b8173c4179a92621dbdbda80c9d05b0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3105,7 +3105,7 @@ dependencies = [
 [[package]]
 name = "celo-proof"
 version = "0.1.0"
-source = "git+https://github.com/celo-org/celo-kona?rev=c90cbe8#c90cbe8e04c5d50138f62b417d58b53ecd8a08e8"
+source = "git+https://github.com/celo-org/celo-kona?rev=eb28668#eb28668b0b8173c4179a92621dbdbda80c9d05b0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3140,7 +3140,7 @@ dependencies = [
 [[package]]
 name = "celo-protocol"
 version = "0.1.0"
-source = "git+https://github.com/celo-org/celo-kona?rev=c90cbe8#c90cbe8e04c5d50138f62b417d58b53ecd8a08e8"
+source = "git+https://github.com/celo-org/celo-kona?rev=eb28668#eb28668b0b8173c4179a92621dbdbda80c9d05b0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3169,7 +3169,7 @@ dependencies = [
 [[package]]
 name = "celo-registry"
 version = "0.1.0"
-source = "git+https://github.com/celo-org/celo-kona?rev=c90cbe8#c90cbe8e04c5d50138f62b417d58b53ecd8a08e8"
+source = "git+https://github.com/celo-org/celo-kona?rev=eb28668#eb28668b0b8173c4179a92621dbdbda80c9d05b0"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -3184,7 +3184,7 @@ dependencies = [
 [[package]]
 name = "celo-revm"
 version = "0.1.0"
-source = "git+https://github.com/celo-org/celo-kona?rev=c90cbe8#c90cbe8e04c5d50138f62b417d58b53ecd8a08e8"
+source = "git+https://github.com/celo-org/celo-kona?rev=eb28668#eb28668b0b8173c4179a92621dbdbda80c9d05b0"
 dependencies = [
  "alloy-eips",
  "alloy-evm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,12 +97,12 @@ kona-genesis = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.1.
 
 # TODO: replace commit hash with tag when available
 # celo-kona
-celo-driver = { git = "https://github.com/celo-org/celo-kona", rev = "c90cbe8" }
-celo-proof = { git = "https://github.com/celo-org/celo-kona", rev = "c90cbe8" }
-celo-host = { git = "https://github.com/celo-org/celo-kona", rev = "c90cbe8" }
-celo-protocol = { git = "https://github.com/celo-org/celo-kona", rev = "c90cbe8", default-features = false }
-celo-genesis = { git = "https://github.com/celo-org/celo-kona", rev = "c90cbe8", default-features = false }
-celo-registry = { git = "https://github.com/celo-org/celo-kona", rev = "c90cbe8", default-features = false }
+celo-driver = { git = "https://github.com/celo-org/celo-kona", rev = "eb28668" }
+celo-proof = { git = "https://github.com/celo-org/celo-kona", rev = "eb28668" }
+celo-host = { git = "https://github.com/celo-org/celo-kona", rev = "eb28668" }
+celo-protocol = { git = "https://github.com/celo-org/celo-kona", rev = "eb28668", default-features = false }
+celo-genesis = { git = "https://github.com/celo-org/celo-kona", rev = "eb28668", default-features = false }
+celo-registry = { git = "https://github.com/celo-org/celo-kona", rev = "eb28668", default-features = false }
 
 # hana
 hana-blobstream = { git = "https://github.com/celestiaorg/hana", rev = "1d272dd83263dbcc2ad97daaac84b2e578a0b288" }
@@ -189,10 +189,10 @@ op-alloy-rpc-types-engine = { version = "0.22.0", default-features = false }
 op-alloy-network = { version = "0.22.0", default-features = false }
 
 # Celo Alloy
-celo-alloy-consensus = { git = "https://github.com/celo-org/celo-kona", rev = "c90cbe8", default-features = false }
-celo-alloy-rpc-types = { git = "https://github.com/celo-org/celo-kona", rev = "c90cbe8", default-features = false }
-celo-alloy-rpc-types-engine = { git = "https://github.com/celo-org/celo-kona", rev = "c90cbe8", default-features = false }
-celo-alloy-network = { git = "https://github.com/celo-org/celo-kona", rev = "c90cbe8", default-features = false }
+celo-alloy-consensus = { git = "https://github.com/celo-org/celo-kona", rev = "eb28668", default-features = false }
+celo-alloy-rpc-types = { git = "https://github.com/celo-org/celo-kona", rev = "eb28668", default-features = false }
+celo-alloy-rpc-types-engine = { git = "https://github.com/celo-org/celo-kona", rev = "eb28668", default-features = false }
+celo-alloy-network = { git = "https://github.com/celo-org/celo-kona", rev = "eb28668", default-features = false }
 
 # Execution
 alloy-evm = { version = "0.23.1", default-features = false }
@@ -205,7 +205,7 @@ revm-precompile = { version = "29.0.1", default-features = false }
 op-revm = { version = "12.0.1", default-features = false }
 
 # Celo Execution
-alloy-celo-evm = { git = "https://github.com/celo-org/celo-kona", rev = "c90cbe8", default-features = false }
+alloy-celo-evm = { git = "https://github.com/celo-org/celo-kona", rev = "eb28668", default-features = false }
 
 # SP1
 sp1-sdk = { version = "=5.2.2", default-features = false, features = ["network"] }

--- a/scripts/utils/bin/fetch_fault_dispute_game_config.rs
+++ b/scripts/utils/bin/fetch_fault_dispute_game_config.rs
@@ -240,6 +240,7 @@ async fn update_fdg_config() -> Result<()> {
 }
 
 use clap::Parser;
+use sp1_sdk::utils;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -260,6 +261,8 @@ async fn main() -> Result<()> {
     } else {
         eprintln!("Warning: Could not find project root. {} file not loaded.", args.env_file);
     }
+
+    utils::setup_logger();
 
     update_fdg_config().await?;
 

--- a/scripts/utils/bin/fetch_l2oo_config.rs
+++ b/scripts/utils/bin/fetch_l2oo_config.rs
@@ -139,6 +139,7 @@ async fn update_l2oo_config() -> Result<()> {
 }
 
 use clap::Parser;
+use sp1_sdk::utils;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -159,6 +160,8 @@ async fn main() -> Result<()> {
     } else {
         eprintln!("Warning: Could not find project root. {} file not loaded.", args.env_file);
     }
+
+    utils::setup_logger();
 
     update_l2oo_config().await?;
 


### PR DESCRIPTION
This imports the celo-kona version from https://github.com/celo-org/celo-kona/pull/135 - this way we can derive the vkeys and rollup config hash that corresponds to the pre-Jovian Chaos network in order to set the game implementation.

This is also relevant for proving and the proposer deriving the correct identity to act on the correct games.

When I run the `just fetch-fdg-config` against the current chaos network, I get the following values:
```
aggregationVkey: "0x00b37da93c30bef199e4f70190c46367ade11ab988c3cff4c661960919718afd"
rangeVkeyCommitment: "0x05ca7dfb1b7ca7a103fa36750d622f81182eb7c9679b9487418968400e2b1a29"
rollupConfigHash: "0x5098fa92f6214d32758cc1c250883cf94301d91aeb6bc8b2be305346801fe52f"
```

The op-node used for checking the rollup-config is running a pre-jovian version `op-node:celo-v2.1.0` - and the hash derived from the celo-kona registry seems to match the one when using the `optimism_rollupConfig` output from that node.