### PR TITLE
Fix proposer to drop games with old ASR

### DIFF
--- a/fault-proof/src/proposer.rs
+++ b/fault-proof/src/proposer.rs
@@ -696,6 +696,7 @@ where
                         break
                     }
                 }
+                GameFetchResult::UnsupportedAnchorStateRegistry => {}
                 GameFetchResult::InvalidGame { index } => {
                     invalid_game_ids.push(index);
                 }
@@ -1356,6 +1357,7 @@ where
     ///
     /// Drop game if:
     /// - The game type is not supported.
+    /// - The game's anchor state registry does not match the configured registry.
     /// - The game type does not respect the expected type when created.
     /// - The output root claim is invalid.
     pub async fn fetch_game(&self, index: U256) -> Result<GameFetchResult> {
@@ -1384,6 +1386,19 @@ where
         }
 
         let contract = OPSuccinctFaultDisputeGame::new(game_address, self.l1_provider.clone());
+
+        // Drop games with different anchor state registry.
+        let anchor_state_registry = contract.anchorStateRegistry().call().await?;
+        if anchor_state_registry != self.config.anchor_state_registry_address {
+            tracing::warn!(
+                game_index = %index,
+                ?game_address,
+                ?anchor_state_registry,
+                expected_anchor_state_registry = ?self.config.anchor_state_registry_address,
+                "Unsupported game with different anchor state registry"
+            );
+            return Ok(GameFetchResult::UnsupportedAnchorStateRegistry);
+        }
 
         let l2_block = contract.l2BlockNumber().call().await?;
         let output_root = self.l2_provider.compute_output_root_at_block(l2_block).await?;
@@ -2215,6 +2230,8 @@ pub enum GameFetchResult {
     ValidGame { game_address: Address, deadline: u64 },
     /// Game type is unsupported
     UnsupportedType { game_address: Address },
+    /// Game's anchor state registry does not match the configured registry
+    UnsupportedAnchorStateRegistry,
     /// Game is invalid
     InvalidGame { index: U256 },
     /// Game was already present in the cache


### PR DESCRIPTION
We encountered [an unexpected proposer bug](https://clabs.grafana.net/a/grafana-lokiexplore-app/explore/service_name/op-succinct/logs?from=2026-03-04T11:50:16.967Z&to=2026-03-04T11:52:00.925Z&var-ds=ddj3u5bd0ejuod&var-filters=op_succinct_mode%7C%3D%7Cproposer&var-filters=service_name%7C%3D%7Cop-succinct&var-filters=instance%7C%3D%7Cop-succinct-proposer-v2&patterns=%5B%5D&var-lineFormat=&var-fields=&var-levels=&var-metadata=&var-jsonFields=&var-patterns=&var-lineFilterV2=&var-lineFilters=&timezone=browser&var-all-fields=&userDisplayedFields=false&displayedFields=%5B%5D&urlColumns=%5B%5D&visualizationType=%22logs%22&prettifyLogMessage=false&sortOrder=%22Ascending%22&wrapLogMessage=false) where it attempted to create a new game with new ASR on top of latest game that was created with old ASR.

This happens because the proposer still tracks games with old ASR in its state and DAG. Since those games still have a valid root claim, the proposer decides to build on top of them. But in our case where a new ASR is deployed and the games with old ASR are considered invalid by the new ASR, the proposer should instead start a fresh game chain without any parent (`parentIndex` set to `u32::MAX`).

So there's no reason to keep the games with old ASR in the proposer's state and DAG. To address this, I added filtering logic during the initial game-fetching phase so that the proposer ignores games with old ASR and creates a new game as if no valid games exist.