### PR TITLE
Increase claimCredit gas limit for setAnchorState partial revert case

### DIFF
--- a/fault-proof/src/proposer.rs
+++ b/fault-proof/src/proposer.rs
@@ -1332,7 +1332,7 @@ where
     pub async fn submit_bond_claim_transaction(&self, game: &Game) -> Result<()> {
         let contract = OPSuccinctFaultDisputeGame::new(game.address, self.l1_provider.clone());
         let transaction_request =
-            contract.claimCredit(self.signer.address()).gas(200_000).into_transaction_request();
+            contract.claimCredit(self.signer.address()).gas(300_000).into_transaction_request();
         let receipt = self
             .signer
             .send_transaction_request(self.config.l1_rpc.clone(), transaction_request)


### PR DESCRIPTION
For the `setAnchorState` partial revert case, 200k gas is not sufficient after upgrading to `OPSuccinctFDG` v2.0.0 (See https://sepolia.etherscan.io/tx/0x9d58def9c61818bfd016d536b5d84049112d3eb8f533d550f24d906a0e0dbd14 which consumes more than 200k gas). We bump the hardcoded limit to 300k since the actual gas usage is slightly higher than 200k.