### PR TITLE
Add calculate_jovian_timestamp.py script

### DIFF
--- a/scripts/calculate_jovian_timestamp.py
+++ b/scripts/calculate_jovian_timestamp.py
@@ -1,0 +1,33 @@
+# Usage:
+# FORK_DATE="2026-03-17T12:00:00" DISPUTE_FACTORY_ADDRESS="" L1_URL="" L2_URL="" python3 ./scripts/calculate_jovian_timestamp.py
+#
+# Description:
+# This script calculates the Jovian timestamp by finding the next L2 block of the first game's l2BlockNumber after the given fork date.
+# See https://github.com/celo-org/celo-blockchain-planning/issues/1327#issuecomment-3951692589 for the reasoning.
+
+
+from datetime import datetime, timezone
+import subprocess, os
+
+dt = datetime.fromisoformat(os.environ["FORK_DATE"]).replace(tzinfo=timezone.utc)
+fork_time_min = int(dt.timestamp())
+def run(cmd):
+    return subprocess.check_output(cmd, shell=True).decode().strip()
+
+DISPUTE_FACTORY_ADDRESS = os.environ["DISPUTE_FACTORY_ADDRESS"]
+L1_URL = os.environ["L1_URL"]
+L2_URL = os.environ["L2_URL"]
+
+game_count = int(run(f'cast to-dec $(cast call {DISPUTE_FACTORY_ADDRESS} "gameCount()" -r {L1_URL})'))
+game_index = game_count - 1
+game_addr = run(f'cast call {DISPUTE_FACTORY_ADDRESS} "gameAtIndex(uint256)(uint32,uint64,address)" {game_index} -r {L1_URL}').splitlines()[-1].strip()
+l2_block = int(run(f'cast to-dec $(cast call {game_addr} "l2BlockNumber()" -r {L1_URL})'))
+current_game_l2_time = int(run(f'cast block {l2_block} -f timestamp -r {L2_URL}'))
+
+next_timestamp = current_game_l2_time
+while next_timestamp < fork_time_min:
+    next_timestamp += 1800
+
+fork_timestamp = next_timestamp + 1
+print('Jovian timestamp: ', fork_timestamp)
+print('Jovian date: ', datetime.fromtimestamp(fork_timestamp, timezone.utc))


### PR DESCRIPTION
## Summary
- Adds `scripts/calculate_jovian_timestamp.py`, a utility that calculates the Jovian fork timestamp
- The script finds the next L2 block after a given fork date based on the latest dispute game's `l2BlockNumber`
- Reference: https://github.com/celo-org/celo-blockchain-planning/issues/1327#issuecomment-3951692589

## Test plan
- [x] Run the script with valid env vars (`FORK_DATE`, `DISPUTE_FACTORY_ADDRESS`, `L1_URL`, `L2_URL`) and verify correct timestamp output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, standalone scripting change with no impact on production code paths; main risk is incorrect results or shell-command failures if env vars/`cast` inputs are wrong.
> 
> **Overview**
> Adds a new `scripts/calculate_jovian_timestamp.py` helper that computes the proposed Jovian fork timestamp from a provided `FORK_DATE` by querying the latest dispute game’s `l2BlockNumber` via `cast`, fetching that L2 block’s timestamp, rounding forward in 30-minute increments, and outputting the resulting timestamp (+1s) and UTC date.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b2fac1886c6d48f7c71948cdf6792a9fb34dc97. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->