### PR TITLE
feat(challenger): filter games by configured ASR address

### DIFF
--- a/fault-proof/src/challenger.rs
+++ b/fault-proof/src/challenger.rs
@@ -355,6 +355,21 @@ where
                 expected_game_type = self.config.game_type,
                 "Dropping game due to invalid game type"
             );
+            self.state.lock().await.cursor = index;
+            return Ok(());
+        }
+
+        // Drop games with different anchor state registry.
+        let anchor_state_registry = contract.anchorStateRegistry().call().await?;
+        if anchor_state_registry != self.config.anchor_state_registry_address {
+            tracing::debug!(
+                game_index = %index,
+                ?game_address,
+                ?anchor_state_registry,
+                expected_anchor_state_registry = ?self.config.anchor_state_registry_address,
+                "Dropping game with different anchor state registry"
+            );
+            self.state.lock().await.cursor = index;
             return Ok(());
         }
 

--- a/fault-proof/tests/challenger_asr_filter.rs
+++ b/fault-proof/tests/challenger_asr_filter.rs
@@ -6,7 +6,7 @@ mod tests {
         constants::{CHALLENGER_PRIVATE_KEY, TEST_GAME_TYPE},
         new_challenger, TestEnvironment,
     };
-    use alloy_primitives::{address, U256};
+    use alloy_primitives::address;
     use anyhow::Result;
 
     const M: u32 = u32::MAX;

--- a/fault-proof/tests/challenger_asr_filter.rs
+++ b/fault-proof/tests/challenger_asr_filter.rs
@@ -1,0 +1,63 @@
+pub mod common;
+
+#[cfg(feature = "integration")]
+mod tests {
+    use crate::common::{
+        constants::{CHALLENGER_PRIVATE_KEY, TEST_GAME_TYPE},
+        new_challenger, TestEnvironment,
+    };
+    use alloy_primitives::{address, U256};
+    use anyhow::Result;
+
+    const M: u32 = u32::MAX;
+
+    /// A dummy ASR address that won't match any deployed contract.
+    const WRONG_ASR: alloy_primitives::Address =
+        address!("0xdead000000000000000000000000000000000001");
+
+    /// Verifies that games are cached when the ASR matches, and filtered when it doesn't.
+    /// Uses two challengers: one with the correct ASR, one with a wrong ASR.
+    #[tokio::test]
+    async fn test_sync_state_filters_different_anchor_state_registry() -> Result<()> {
+        let env = TestEnvironment::setup().await?;
+        let factory = env.factory()?;
+        let init_bond = factory.initBonds(TEST_GAME_TYPE).call().await?;
+
+        // Create a challenger with the correct ASR.
+        let correct_challenger = env.init_challenger().await?;
+
+        // Create a challenger with a wrong ASR.
+        let wrong_challenger = new_challenger(
+            &env.rpc_config,
+            CHALLENGER_PRIVATE_KEY,
+            &WRONG_ASR,
+            &env.deployed.factory,
+            env.game_type,
+            None,
+        )
+        .await?;
+
+        let starting_l2_block = env.anvil.starting_l2_block_number;
+
+        // Create a valid game.
+        let block = starting_l2_block + 1;
+        let root_claim = env.compute_output_root_at_block(block).await?;
+        env.create_game(root_claim, block, M, init_bond).await?;
+
+        correct_challenger.sync_state().await?;
+        wrong_challenger.sync_state().await?;
+
+        assert_eq!(
+            correct_challenger.cached_game_count().await,
+            1,
+            "Correct ASR challenger should cache the game"
+        );
+        assert_eq!(
+            wrong_challenger.cached_game_count().await,
+            0,
+            "Wrong ASR challenger should filter out the game"
+        );
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Skip games whose anchor state registry doesn't match the configured address, so the challenger doesn't track or challenge games from a previous ASR deployment. Also advance the cursor on early returns to avoid re-fetching dropped games every sync cycle.

Relates to celo-org/celo-blockchain-planning#1363

With regards to this comment (https://github.com/celo-org/celo-blockchain-planning/issues/1363#issuecomment-4119322980) I think, the current implementation works assuming that the current dispute game impl is pointing to the correct ASR and that the challenger has that ASR configured.