### PR TITLE
Revert "fix(fault-proof): conditionally allow earlier-parent games as canonical head 

### DIFF
--- a/fault-proof/src/proposer.rs
+++ b/fault-proof/src/proposer.rs
@@ -921,41 +921,21 @@ where
 
     /// Computes the canonical head by scanning all cached games.
     ///
-    /// Canonical head is the game with the highest L2 block number. When an anchor game exists,
-    /// the canonical head is chosen from its descendants, unless a non-descendant has a higher L2
-    /// block number and an earlier lineage (parent is genesis or has a lower parent index than the
-    /// best descendant).
+    /// Canonical head is the game with the highest L2 block number. When an anchor game is present,
+    /// only its descendants are eligible for canonical head.
     async fn compute_canonical_head(&self) {
         let mut state = self.state.write().await;
 
-        let canonical_head = match state.anchor_game.as_ref() {
-            None => state.games.values().max_by_key(|g| g.l2_block).cloned(),
-            Some(anchor_game) => {
-                let reachable = state.descendants_of(anchor_game.index);
-
-                // Best among descendants
-                let anchor_head = state
-                    .games
-                    .values()
-                    .filter(|g| reachable.contains(&g.index))
-                    .max_by_key(|g| g.l2_block);
-
-                // Check non-descendants for override (higher block with genesis or lower parent)
-                let override_head = anchor_head.and_then(|anchor| {
-                    state
-                        .games
-                        .values()
-                        .filter(|g| !reachable.contains(&g.index))
-                        .filter(|g| {
-                            g.l2_block > anchor.l2_block &&
-                                (g.parent_index == u32::MAX ||
-                                    g.parent_index < anchor.parent_index)
-                        })
-                        .max_by_key(|g| g.l2_block)
-                });
-
-                override_head.or(anchor_head).cloned()
-            }
+        let canonical_head = if let Some(anchor_game) = state.anchor_game.as_ref() {
+            let reachable = state.descendants_of(anchor_game.index);
+            state
+                .games
+                .values()
+                .filter(|game| reachable.contains(&game.index))
+                .max_by_key(|game| game.l2_block)
+                .cloned()
+        } else {
+            state.games.values().max_by_key(|game| game.l2_block).cloned()
         };
 
         let previous_canonical_index = state.canonical_head_index;

--- a/fault-proof/tests/sync.rs
+++ b/fault-proof/tests/sync.rs
@@ -116,9 +116,7 @@ mod proposer_sync {
     #[case::noanch_five_games_three_branches(5, &[], &[M, 0, 1, 0, 0], &[1, 1, 1, 4, 3], Some(3), 5)] // Branches: M->0->1->2, 0->3, 0->4, Blocks: 0->1->2->3, 1->5, 1->4
     #[case::anch_single_game_default_interval(1, &[0], &[M], &[], Some(0), 1)]
     #[case::anch_two_games_same_branch(2, &[0, 1], &[M, 0], &[], Some(1), 2)]
-    #[case::anch_two_games_genesis_parent_override(2, &[0], &[M, M], &[1, 2], Some(1), 2)] // M->0(anchor), M->1, game 1 overrides (genesis, higher block)
-    #[case::anch_lower_parent_override(4, &[0, 1], &[M, 0, 1, 0], &[1, 1, 1, 3], Some(3), 4)] // M->0->1(anchor)->2, 0->3, game 3 overrides (lower parent, higher block)
-    #[case::anch_no_override_lower_block(4, &[0, 1], &[M, 0, 1, 0], &[1, 1, 2, 2], Some(2), 4)] // M->0->1(anchor)->2, 0->3, no override (game 3 block < game 2)
+    #[case::anch_two_games_same_parent_diff_intervals(2, &[0], &[M, M], &[1, 2], Some(0), 1)]
     #[case::anch_five_games_two_branches(5, &[0, 1], &[M, 0, 1, 0, 3], &[1, 1, 1, 2, 2], Some(2), 3)]
     #[tokio::test]
     async fn test_sync_state_happy_paths(


### PR DESCRIPTION
This reverts commit https://github.com/celo-org/op-succinct-ghsa-qjmw-q2xw-v4xq/commit/4c54d242d687cfc63a9636150bc5f153d565ed27.

While this might have solved a very https://github.com/succinctlabs/op-succinct/issues/735 that is only relevant for permissionless mode, it does introduce some other issues.
For example for an unknown unrelated reason, our proposer falsely created a wrong game with a recent l2-block number and the genesis-parent index.
This and the condition intoduced in https://github.com/celo-org/op-succinct-ghsa-qjmw-q2xw-v4xq/commit/4c54d242d687cfc63a9636150bc5f153d565ed27 now poisoned the internal canonical tracking even after a restart and all new games will be built on top of that.
(This would also happen if a malicous actor created such a game)