### PR TITLE
Game monitor reliability

### DIFF
--- a/scripts/utils/bin/game_monitor.rs
+++ b/scripts/utils/bin/game_monitor.rs
@@ -28,7 +28,7 @@ use std::{
     collections::{HashMap, VecDeque},
     env,
     fs::{self, File},
-    io::Write,
+    io::{Read, Seek, SeekFrom, Write},
     path::{Path, PathBuf},
     process::{Child, Command, Stdio},
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
@@ -565,10 +565,16 @@ impl MonitorState {
                             },
                         ));
                     } else {
+                        // Classify the failure log before logging so the failure type is
+                        // included inline. Grep for `failure type unknown` to find failures
+                        // not covered by an existing pattern.
+                        let failure_type = detect_failure_type(&estimator.log_file.path);
                         error!(
-                            "Cost estimator {} failed with status {:?}, log file: {}",
+                            "Cost estimator {} failed with status {:?}, failure type {}, \
+                             log file: {}",
                             id,
                             status,
+                            failure_type,
                             estimator.log_file.path.display(),
                         );
                         process_actions.push((
@@ -923,6 +929,111 @@ fn atomic_write(path: &Path, data: &[u8]) -> std::io::Result<()> {
     };
     fs::write(&tmp_path, data)?;
     fs::rename(&tmp_path, path)
+}
+
+/// Classification of the cause of a cost-estimator failure, derived from the tail of its
+/// failure log. The non-`Unknown` variants all represent transient environmental issues (RPC
+/// backend health, missing state, DNS resolution) rather than programmatic faults, so flagging
+/// them lets the daemon distinguish "infra was sick" from "the estimator is broken" when
+/// primary retries are exhausted.
+#[derive(Debug, Clone, Copy)]
+enum FailureType {
+    /// `HTTP error 503 ... no backend is currently healthy to serve traffic` (JSON-RPC code
+    /// `-32011`). The proxy in front of the L1/L2 nodes returned 503 because none of its
+    /// backends were healthy.
+    NoHealthyBackend,
+    /// `No state available for block ...` (JSON-RPC code `-32002`). The RPC node pruned or
+    /// never had state for the requested historical block.
+    NoStateAvailable,
+    /// `distance to target block exceeds maximum proof window` (JSON-RPC code `-32602`). The
+    /// requested block is too far from the node's head for an `eth_getProof` call.
+    ExceedsProofWindow,
+    /// `missing trie node ... is not available` (JSON-RPC code `-32000`). The RPC node is
+    /// missing a trie node for the requested state.
+    MissingTrieNode,
+    /// `Failed to fetch safe head` with a `dns error` cause. The op-node hostname could not be
+    /// resolved (typically a transient cluster-DNS hiccup).
+    DnsLookupFailure,
+    /// No known pattern matched. Either the log could not be read, or the failure mode is
+    /// new/programmatic; callers should treat this as "not a known infrastructure failure"
+    /// rather than as a positive signal of a code bug.
+    Unknown,
+}
+
+/// Short human-readable description suitable for inclusion in a log line. The string is
+/// stable and grep-friendly; in particular, [`FailureType::Unknown`] renders as the literal
+/// `"unknown"` so an operator can scan logs for failures lacking a classification.
+impl std::fmt::Display for FailureType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::NoHealthyBackend => "no healthy RPC backend (HTTP 503)",
+            Self::NoStateAvailable => "RPC node has no state for requested block",
+            Self::ExceedsProofWindow => "distance to target block exceeds maximum proof window",
+            Self::MissingTrieNode => "RPC node missing trie node",
+            Self::DnsLookupFailure => "DNS lookup failure",
+            Self::Unknown => "unknown",
+        };
+        f.write_str(s)
+    }
+}
+
+/// Maximum number of trailing bytes scanned by [`detect_failure_type`]. Analysis of historical
+/// failure logs shows the canonical error line is within ~100 lines (and ~500 KiB worst-case,
+/// when several worker threads panicked before the main thread) of EOF; 1 MiB covers every
+/// observed case with margin.
+const FAILURE_SCAN_TAIL_BYTES: u64 = 1024 * 1024;
+
+/// Patterns matched against each line of the failure log, in descending order of observed
+/// frequency. Each entry is the set of substrings that must all appear in a single line for
+/// the classification to apply; matching is intentionally loose (substring rather than full
+/// regex) because the chosen anchors are invariant across thread ids, request ids, and
+/// addresses. Scoping each match to a single line — rather than the whole tail — prevents
+/// false positives where two unrelated log entries happen to contain the constituent
+/// substrings of a multi-needle pattern (notably [`FailureType::DnsLookupFailure`]).
+const FAILURE_PATTERNS: &[(&[&str], FailureType)] = &[
+    (&["no backend is currently healthy to serve traffic"], FailureType::NoHealthyBackend),
+    (&["No state available for block"], FailureType::NoStateAvailable),
+    (&["distance to target block exceeds maximum proof window"], FailureType::ExceedsProofWindow),
+    (&["missing trie node"], FailureType::MissingTrieNode),
+    (&["Failed to fetch safe head", "dns error"], FailureType::DnsLookupFailure),
+];
+
+/// Classify the tail of a failure log against the known cost-estimator failure patterns.
+///
+/// The function reads at most [`FAILURE_SCAN_TAIL_BYTES`] from the end of the file and matches
+/// each line against [`FAILURE_PATTERNS`], returning the first matching classification.
+/// Patterns are derived from a survey of historical failure logs (see the
+/// `forno-eu-game-monitor-logs/` corpus).
+///
+/// Returns [`FailureType::Unknown`] for I/O errors or for any failure mode not covered by the
+/// patterns above.
+fn detect_failure_type(log_path: &Path) -> FailureType {
+    let Ok(mut file) = File::open(log_path) else {
+        return FailureType::Unknown;
+    };
+    let Ok(metadata) = file.metadata() else {
+        return FailureType::Unknown;
+    };
+    let len = metadata.len();
+    let start = len.saturating_sub(FAILURE_SCAN_TAIL_BYTES);
+    if start > 0 && file.seek(SeekFrom::Start(start)).is_err() {
+        return FailureType::Unknown;
+    }
+    let mut bytes = Vec::new();
+    if file.read_to_end(&mut bytes).is_err() {
+        return FailureType::Unknown;
+    }
+    let tail = String::from_utf8_lossy(&bytes);
+
+    tail.lines().find_map(classify_line).unwrap_or(FailureType::Unknown)
+}
+
+/// Match a single log line against [`FAILURE_PATTERNS`] in priority order.
+fn classify_line(line: &str) -> Option<FailureType> {
+    FAILURE_PATTERNS
+        .iter()
+        .find(|(patterns, _)| patterns.iter().all(|n| line.contains(n)))
+        .map(|(_, ft)| *ft)
 }
 
 /// Compute the median of `values`. Returns `None` if fewer than `threshold` entries are

--- a/scripts/utils/bin/game_monitor.rs
+++ b/scripts/utils/bin/game_monitor.rs
@@ -288,6 +288,11 @@ enum SpawnOutcome {
     /// Fetching game data from L1/L2 failed. Queues are unmodified so the entry will be retried
     /// on the next poll. Callers typically `continue 'outer` to abandon the current iteration.
     FetchFailed,
+    /// The L2 finalized block is behind the game's end block, so the cost estimator would have
+    /// nothing to execute against. The entry is left in its queue; the caller should skip this
+    /// candidate and try the next one (older games in the queue may have lower end blocks the
+    /// L2 has already finalised). The next poll will re-check skipped entries.
+    L2Behind,
 }
 
 /// Bundles the per-spawn configuration that doesn't change across loop iterations. Built once
@@ -295,6 +300,9 @@ enum SpawnOutcome {
 struct SpawnContext<'a, P: alloy_provider::Provider + Clone> {
     factory: &'a DisputeGameFactoryInstance<P>,
     l1_provider: &'a P,
+    /// L2 (op-geth) provider used to read the finalized head before spawning. Games whose end
+    /// block is ahead of the L2 finalized block can't be executed yet and are deferred.
+    l2_provider: &'a P,
     cost_estimator_binary_path: &'a Path,
     batch_size: u64,
     env_file: &'a Path,
@@ -850,6 +858,36 @@ impl MonitorState {
                 }
             };
 
+        // A game can be posted on L1 before the L2 has actually produced (or finalised) all of
+        // the blocks it covers. Running the cost estimator in that state would either fail or
+        // produce a misleading result, so we defer until the L2 catches up. The next poll will
+        // re-check.
+        let l2_finalized_block = match ctx.l2_provider.get_block(BlockId::finalized()).await {
+            Ok(Some(block)) => block.header.number,
+            Ok(None) => {
+                warn!(
+                    "L2 finalized block not returned by provider; deferring spawn of game {}",
+                    game_data.game_index,
+                );
+                return Ok(SpawnOutcome::FetchFailed);
+            }
+            Err(e) => {
+                warn!(
+                    "Failed to fetch L2 finalized block for game {}: {:#}. Retrying",
+                    game_data.game_index, e,
+                );
+                return Ok(SpawnOutcome::FetchFailed);
+            }
+        };
+        if l2_finalized_block < game_data.end_block {
+            warn!(
+                "L2 finalized block {} is behind game {} end block {}; deferring spawn until \
+                 the L2 catches up",
+                l2_finalized_block, game_data.game_index, game_data.end_block,
+            );
+            return Ok(SpawnOutcome::L2Behind);
+        }
+
         let log_file =
             LogFile::new(ctx.logs_dir, game_data.game_index, game_data.game_address, kind);
         let child = spawn_cost_estimator(
@@ -1335,16 +1373,20 @@ async fn run(args: RunArgs) -> Result<()> {
 
     // Get required environment variables
     let l1_rpc = env::var("L1_RPC").context("L1_RPC not set")?;
+    let l2_rpc = env::var("L2_RPC").context("L2_RPC not set")?;
     let dispute_game_factory_address = env::var("DISPUTE_GAME_FACTORY_ADDRESS")
         .context("DISPUTE_GAME_FACTORY_ADDRESS not set")?
         .parse::<Address>()
         .context("Invalid DISPUTE_GAME_FACTORY_ADDRESS")?;
 
     info!("L1 RPC: {}", l1_rpc);
+    info!("L2 RPC: {}", l2_rpc);
     info!("Dispute Game Factory: {}", dispute_game_factory_address);
 
-    // Set up L1 provider and factory contract
+    // Set up L1 and L2 providers, and the factory contract. The L2 provider is used during
+    // spawn scheduling to verify the L2 has finalised the game's end block; see `spawn_game`.
     let l1_provider = ProviderBuilder::new().connect_http(l1_rpc.parse()?);
+    let l2_provider = ProviderBuilder::new().connect_http(l2_rpc.parse()?);
     let factory =
         DisputeGameFactoryInstance::new(dispute_game_factory_address, l1_provider.clone());
 
@@ -1403,6 +1445,7 @@ async fn run(args: RunArgs) -> Result<()> {
     let spawn_ctx = SpawnContext {
         factory: &factory,
         l1_provider: &l1_provider,
+        l2_provider: &l2_provider,
         cost_estimator_binary_path: args.cost_estimator_binary_path.as_path(),
         batch_size: args.batch_size,
         env_file: args.env_file.as_path(),
@@ -1450,18 +1493,24 @@ async fn run(args: RunArgs) -> Result<()> {
         );
 
         // Phase 4: spawn pending primary games whose delay has elapsed, up to max_concurrent.
+        // A snapshot of the eligible candidates is taken once so we can iterate without
+        // holding a borrow on `state.pending_games`; `spawn_game` only mutates the entry it
+        // operates on, so other snapshot entries remain valid as we walk through them.
         let current_time = Instant::now();
-        while state.can_spawn_new(args.max_concurrent) {
-            let Some((game_index, kind)) = state
-                .pending_games
-                .iter()
-                .find(|p| p.executable_at <= current_time)
-                .map(|p| (p.game_index, p.kind))
-            else {
-                break; // nothing ready in the queue
-            };
-            if state.spawn_game(game_index, kind, &spawn_ctx).await? == SpawnOutcome::FetchFailed {
-                continue 'outer;
+        let primary_candidates: Vec<(u64, AttemptKind)> = state
+            .pending_games
+            .iter()
+            .filter(|p| p.executable_at <= current_time)
+            .map(|p| (p.game_index, p.kind))
+            .collect();
+        for (game_index, kind) in primary_candidates {
+            if !state.can_spawn_new(args.max_concurrent) {
+                break;
+            }
+            match state.spawn_game(game_index, kind, &spawn_ctx).await? {
+                SpawnOutcome::FetchFailed => continue 'outer,
+                SpawnOutcome::L2Behind => continue,
+                SpawnOutcome::Spawned | SpawnOutcome::WrongGameType => {}
             }
         }
 
@@ -1472,25 +1521,24 @@ async fn run(args: RunArgs) -> Result<()> {
         let primary_has_ready =
             state.pending_games.iter().any(|p| p.executable_at <= Instant::now());
         if !primary_has_ready {
-            while state.can_spawn_new(args.max_concurrent) {
-                let now_sys = SystemTime::now();
-                let Some((game_index, kind)) = state
-                    .background_retries
-                    .iter()
-                    .find(|bg| {
-                        bg.next_attempt_at <= now_sys &&
-                            !state.running_processes.contains_key(&bg.game_index)
-                    })
-                    .map(|bg| {
-                        (bg.game_index, AttemptKind::Background { attempts: bg.attempts + 1 })
-                    })
-                else {
+            let now_sys = SystemTime::now();
+            let background_candidates: Vec<(u64, AttemptKind)> = state
+                .background_retries
+                .iter()
+                .filter(|bg| {
+                    bg.next_attempt_at <= now_sys &&
+                        !state.running_processes.contains_key(&bg.game_index)
+                })
+                .map(|bg| (bg.game_index, AttemptKind::Background { attempts: bg.attempts + 1 }))
+                .collect();
+            for (game_index, kind) in background_candidates {
+                if !state.can_spawn_new(args.max_concurrent) {
                     break;
-                };
-                if state.spawn_game(game_index, kind, &spawn_ctx).await? ==
-                    SpawnOutcome::FetchFailed
-                {
-                    continue 'outer;
+                }
+                match state.spawn_game(game_index, kind, &spawn_ctx).await? {
+                    SpawnOutcome::FetchFailed => continue 'outer,
+                    SpawnOutcome::L2Behind => continue,
+                    SpawnOutcome::Spawned | SpawnOutcome::WrongGameType => {}
                 }
             }
         }

--- a/scripts/utils/bin/game_monitor.rs
+++ b/scripts/utils/bin/game_monitor.rs
@@ -1514,32 +1514,27 @@ async fn run(args: RunArgs) -> Result<()> {
             }
         }
 
-        // Phase 5: spawn background retries using spare slots. Only runs when no primary
-        // entries are ready, so primary scheduling always wins on contention. Entries stay in
-        // background_retries while running so maybe_requeue can update them on failure;
-        // cleanup_finished_processes removes them on success.
-        let primary_has_ready =
-            state.pending_games.iter().any(|p| p.executable_at <= Instant::now());
-        if !primary_has_ready {
-            let now_sys = SystemTime::now();
-            let background_candidates: Vec<(u64, AttemptKind)> = state
-                .background_retries
-                .iter()
-                .filter(|bg| {
-                    bg.next_attempt_at <= now_sys &&
-                        !state.running_processes.contains_key(&bg.game_index)
-                })
-                .map(|bg| (bg.game_index, AttemptKind::Background { attempts: bg.attempts + 1 }))
-                .collect();
-            for (game_index, kind) in background_candidates {
-                if !state.can_spawn_new(args.max_concurrent) {
-                    break;
-                }
-                match state.spawn_game(game_index, kind, &spawn_ctx).await? {
-                    SpawnOutcome::FetchFailed => continue 'outer,
-                    SpawnOutcome::L2Behind => continue,
-                    SpawnOutcome::Spawned | SpawnOutcome::WrongGameType => {}
-                }
+        // Phase 5: spawn background retries using spare slots. Entries stay in background_retries
+        // while running so maybe_requeue can update them on failure; cleanup_finished_processes
+        // removes them on success.
+        let now_sys = SystemTime::now();
+        let background_candidates: Vec<(u64, AttemptKind)> = state
+            .background_retries
+            .iter()
+            .filter(|bg| {
+                bg.next_attempt_at <= now_sys &&
+                    !state.running_processes.contains_key(&bg.game_index)
+            })
+            .map(|bg| (bg.game_index, AttemptKind::Background { attempts: bg.attempts + 1 }))
+            .collect();
+        for (game_index, kind) in background_candidates {
+            if !state.can_spawn_new(args.max_concurrent) {
+                break;
+            }
+            match state.spawn_game(game_index, kind, &spawn_ctx).await? {
+                SpawnOutcome::FetchFailed => continue 'outer,
+                SpawnOutcome::L2Behind => continue,
+                SpawnOutcome::Spawned | SpawnOutcome::WrongGameType => {}
             }
         }
 


### PR DESCRIPTION
Adds two improvements:

1.  Scans failed cost estimator logs to identify transient infrastructure errors, this will allow us to avoid alerting in these cases.
2. If the L2 RPC finalized block is behind the last block of a game that we want to execute we wait instead of executing the game and then having it fail immediately. 