### PR TITLE
game-monitor/cost-estimator: survive an incomplete op-node safeDB

### DIFF
--- a/scripts/utils/bin/cost_estimator.rs
+++ b/scripts/utils/bin/cost_estimator.rs
@@ -299,7 +299,7 @@ async fn main() -> Result<()> {
 
     let host_args = futures::stream::iter(split_ranges.iter())
         .map(|range| async {
-            host.fetch(range.start, range.end, None, args.safe_db_fallback)
+            host.fetch(range.start, range.end, args.l1_head, args.safe_db_fallback)
                 .await
                 .expect("Failed to get host CLI args")
         })

--- a/scripts/utils/bin/cost_estimator.rs
+++ b/scripts/utils/bin/cost_estimator.rs
@@ -281,11 +281,14 @@ async fn main() -> Result<()> {
         .await?
     };
 
-    // Check if the safeDB is activated on the L2 node. If it is, we use the safeHead based range
-    // splitting algorithm. Otherwise, we use the simple range splitting algorithm.
-    let safe_db_activated = data_fetcher.is_safe_db_activated().await?;
-
-    let split_ranges = if safe_db_activated && !args.no_safe_head_split {
+    // Pick the splitter. With --no-safe-head-split the caller wants the basic fixed-size splitter
+    // regardless, so skip the is_safe_db_activated() probe entirely: that probe queries the op-node
+    // safeDB (optimism_safeHeadAtL1Block), which may be disabled or unreachable, and there is no
+    // reason to touch it on a path that will not use safeHead-aligned splitting. Otherwise probe,
+    // and use the basic splitter when the safeDB is not active.
+    let split_ranges = if args.no_safe_head_split {
+        split_range_basic(l2_start_block, l2_end_block, args.effective_batch_size())
+    } else if data_fetcher.is_safe_db_activated().await? {
         split_range_based_on_safe_heads(l2_start_block, l2_end_block, args.effective_batch_size())
             .await?
     } else {

--- a/scripts/utils/bin/game_monitor.rs
+++ b/scripts/utils/bin/game_monitor.rs
@@ -14,7 +14,7 @@
 //! the daemon can resume after restarts.
 
 use alloy_eips::BlockId;
-use alloy_primitives::{Address, U256};
+use alloy_primitives::{Address, B256, U256};
 use alloy_provider::ProviderBuilder;
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
@@ -255,6 +255,9 @@ struct GameData {
     start_block: u64,
     /// L2 block at which the game's execution range ends.
     end_block: u64,
+    /// L1 head the game is anchored to on-chain. Forwarded to the cost estimator so it matches the
+    /// proposer instead of looking the L1 head up via the op-node safeDB.
+    l1_head: B256,
     /// L1 wall-clock time at which the game was created on the dispute game factory. Used for
     /// age-based eviction of background retries.
     created_at: SystemTime,
@@ -1156,7 +1159,16 @@ async fn fetch_game_data<P: alloy_provider::Provider + Clone>(
         .context("failed to get starting block number")?
         .to::<u64>();
 
-    Ok(GameData { game_index, game_address, start_block, end_block: l2_block_number, created_at })
+    let l1_head = game.l1Head().call().await.context("failed to get L1 head")?;
+
+    Ok(GameData {
+        game_index,
+        game_address,
+        start_block,
+        end_block: l2_block_number,
+        l1_head,
+        created_at,
+    })
 }
 
 /// Spawn a `cost-estimator` child process for the given game.
@@ -1183,6 +1195,9 @@ fn spawn_cost_estimator(
         "--env-file",
         env_file.to_str().unwrap(),
         "--log-only",
+        "--no-safe-head-split",
+        "--l1-head",
+        &game_data.l1_head.to_string(),
     ];
 
     let cmd = format!("{} {}", cost_estimator_binary_path.display(), args.join(" "));

--- a/scripts/utils/src/lib.rs
+++ b/scripts/utils/src/lib.rs
@@ -1,3 +1,4 @@
+use alloy_primitives::B256;
 use clap::Parser;
 use std::{num::NonZeroU64, path::PathBuf};
 
@@ -36,6 +37,11 @@ pub struct HostExecutorArgs {
     /// activated for op-node.
     #[clap(long)]
     pub safe_db_fallback: bool,
+    /// L1 head block hash to derive the L2 range from. When set, it is used directly instead of
+    /// looking it up via the op-node safeDB, so a caller who knows L1 head already can skip the
+    /// binary search to find the L1 block from which the `l2_end_block` can be derived.
+    #[arg(long)]
+    pub l1_head: Option<B256>,
     /// Skip writing CSV files and only log execution statistics.
     #[arg(long)]
     pub log_only: bool,
@@ -100,6 +106,7 @@ mod tests {
             env_file: PathBuf::from(".env"),
             prove: false,
             safe_db_fallback: false,
+            l1_head: None,
             cluster_timeout: 21600,
             log_only: false,
             no_safe_head_split: false,


### PR DESCRIPTION
The op-succinct game-monitor spawns a cost-estimator per dispute game to pre-check that the game is provable. The cost-estimator depended on the op-node safeDB (`optimism_safeHeadAtL1Block`) for both range splitting and the L1 head, and aborted when the safeDB was incomplete. On op-nodes that EL-sync (`l2.enginekind=reth` + `syncmode=execution-layer`) the safeDB is wiped to genesis on every restart and refills only forward, so a routine restart made the game-monitor fail continuously (root cause tracked in celo-org/celo-blockchain-planning#1399).

This makes the game-monitor run the cost-estimator without depending on the safeDB at all, by estimating the way the fault-proof proposer proves: basic (fixed-size) range splitting and the on-chain L1 head. The proposer chunks a range by `RANGE_SPLIT_COUNT` rather than by span-batch boundaries, so this also gives a more representative estimate than the safeHead-aligned split.

- **cost-estimator: skip the safeDB probe when `--no-safe-head-split` is set.** The split selection probed `is_safe_db_activated()` unconditionally, before checking `--no-safe-head-split`. That probe queries the safeDB and errored on an incomplete one, so `--no-safe-head-split` still hit the safeDB. Reorder so the probe runs only on the path that uses it: `--no-safe-head-split` goes straight to the basic splitter without touching the safeDB. Behavior is unchanged when the flag is not set.
- **cost-estimator: add optional `--l1-head`.** `host.fetch` already accepts an optional L1 head; expose it. When set, the L1 head is used directly and the safeDB lookup (`get_l1_head`, and the `--safe-db-fallback` timestamp estimation) is skipped.
- **game-monitor: pass `--no-safe-head-split` and `--l1-head`.** Fetch the on-chain `l1Head()` of each game and forward it via `--l1-head`, and force basic splitting via `--no-safe-head-split`. The estimate then uses the same L1 head the proposer proves against and the same chunking, and queries the safeDB on neither the split nor the fetch path.

Net effect: the game-monitor no longer needs a complete safeDB or the `SAFE_DB_FALLBACK` flag. The op-node-side root cause (EL sync wiping the safeDB) is tracked separately in celo-org/celo-blockchain-planning#1399.

The op-succinct fault-proof proposer and challenger are unaffected: they take the L1 head from the on-chain game and never query the safeDB.

Relates to https://github.com/celo-org/celo-blockchain-planning/issues/1400