### PR TITLE
fix(host): enable the debug_executePayload witness endpoint via celo-kona v1.1.1 (no ELF change)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,7 +111,7 @@ dependencies = [
 [[package]]
 name = "alloy-celo-evm"
 version = "1.0.0"
-source = "git+https://github.com/celo-org/celo-kona?rev=61caf47#61caf474624cd8d31fcd689eb2b5ba8979701076"
+source = "git+https://github.com/celo-org/celo-kona?tag=celo%2Fv1.1.1#15ef22fc1af72f2571331df18399185a9e4a4baa"
 dependencies = [
  "alloy-consensus",
  "alloy-evm 0.27.3",
@@ -2922,7 +2922,7 @@ dependencies = [
 [[package]]
 name = "celo-alloy-consensus"
 version = "1.0.0"
-source = "git+https://github.com/celo-org/celo-kona?rev=61caf47#61caf474624cd8d31fcd689eb2b5ba8979701076"
+source = "git+https://github.com/celo-org/celo-kona?tag=celo%2Fv1.1.1#15ef22fc1af72f2571331df18399185a9e4a4baa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2937,7 +2937,7 @@ dependencies = [
 [[package]]
 name = "celo-alloy-network"
 version = "1.0.0"
-source = "git+https://github.com/celo-org/celo-kona?rev=61caf47#61caf474624cd8d31fcd689eb2b5ba8979701076"
+source = "git+https://github.com/celo-org/celo-kona?tag=celo%2Fv1.1.1#15ef22fc1af72f2571331df18399185a9e4a4baa"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -2951,7 +2951,7 @@ dependencies = [
 [[package]]
 name = "celo-alloy-rpc-types"
 version = "1.0.0"
-source = "git+https://github.com/celo-org/celo-kona?rev=61caf47#61caf474624cd8d31fcd689eb2b5ba8979701076"
+source = "git+https://github.com/celo-org/celo-kona?tag=celo%2Fv1.1.1#15ef22fc1af72f2571331df18399185a9e4a4baa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2970,7 +2970,7 @@ dependencies = [
 [[package]]
 name = "celo-alloy-rpc-types-engine"
 version = "1.0.0"
-source = "git+https://github.com/celo-org/celo-kona?rev=61caf47#61caf474624cd8d31fcd689eb2b5ba8979701076"
+source = "git+https://github.com/celo-org/celo-kona?tag=celo%2Fv1.1.1#15ef22fc1af72f2571331df18399185a9e4a4baa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2986,7 +2986,7 @@ dependencies = [
 [[package]]
 name = "celo-client"
 version = "1.0.0"
-source = "git+https://github.com/celo-org/celo-kona?rev=61caf47#61caf474624cd8d31fcd689eb2b5ba8979701076"
+source = "git+https://github.com/celo-org/celo-kona?tag=celo%2Fv1.1.1#15ef22fc1af72f2571331df18399185a9e4a4baa"
 dependencies = [
  "alloy-celo-evm",
  "alloy-consensus",
@@ -3011,7 +3011,7 @@ dependencies = [
 [[package]]
 name = "celo-driver"
 version = "1.0.0"
-source = "git+https://github.com/celo-org/celo-kona?rev=61caf47#61caf474624cd8d31fcd689eb2b5ba8979701076"
+source = "git+https://github.com/celo-org/celo-kona?tag=celo%2Fv1.1.1#15ef22fc1af72f2571331df18399185a9e4a4baa"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -3041,7 +3041,7 @@ dependencies = [
 [[package]]
 name = "celo-executor"
 version = "1.0.0"
-source = "git+https://github.com/celo-org/celo-kona?rev=61caf47#61caf474624cd8d31fcd689eb2b5ba8979701076"
+source = "git+https://github.com/celo-org/celo-kona?tag=celo%2Fv1.1.1#15ef22fc1af72f2571331df18399185a9e4a4baa"
 dependencies = [
  "alloy-celo-evm",
  "alloy-consensus",
@@ -3069,7 +3069,7 @@ dependencies = [
 [[package]]
 name = "celo-genesis"
 version = "1.0.0"
-source = "git+https://github.com/celo-org/celo-kona?rev=61caf47#61caf474624cd8d31fcd689eb2b5ba8979701076"
+source = "git+https://github.com/celo-org/celo-kona?tag=celo%2Fv1.1.1#15ef22fc1af72f2571331df18399185a9e4a4baa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3089,7 +3089,7 @@ dependencies = [
 [[package]]
 name = "celo-host"
 version = "1.0.0"
-source = "git+https://github.com/celo-org/celo-kona?rev=61caf47#61caf474624cd8d31fcd689eb2b5ba8979701076"
+source = "git+https://github.com/celo-org/celo-kona?tag=celo%2Fv1.1.1#15ef22fc1af72f2571331df18399185a9e4a4baa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3126,7 +3126,7 @@ dependencies = [
 [[package]]
 name = "celo-proof"
 version = "1.0.0"
-source = "git+https://github.com/celo-org/celo-kona?rev=61caf47#61caf474624cd8d31fcd689eb2b5ba8979701076"
+source = "git+https://github.com/celo-org/celo-kona?tag=celo%2Fv1.1.1#15ef22fc1af72f2571331df18399185a9e4a4baa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3161,7 +3161,7 @@ dependencies = [
 [[package]]
 name = "celo-protocol"
 version = "1.0.0"
-source = "git+https://github.com/celo-org/celo-kona?rev=61caf47#61caf474624cd8d31fcd689eb2b5ba8979701076"
+source = "git+https://github.com/celo-org/celo-kona?tag=celo%2Fv1.1.1#15ef22fc1af72f2571331df18399185a9e4a4baa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3190,7 +3190,7 @@ dependencies = [
 [[package]]
 name = "celo-registry"
 version = "1.0.0"
-source = "git+https://github.com/celo-org/celo-kona?rev=61caf47#61caf474624cd8d31fcd689eb2b5ba8979701076"
+source = "git+https://github.com/celo-org/celo-kona?tag=celo%2Fv1.1.1#15ef22fc1af72f2571331df18399185a9e4a4baa"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -3204,7 +3204,7 @@ dependencies = [
 [[package]]
 name = "celo-revm"
 version = "1.0.0"
-source = "git+https://github.com/celo-org/celo-kona?rev=61caf47#61caf474624cd8d31fcd689eb2b5ba8979701076"
+source = "git+https://github.com/celo-org/celo-kona?tag=celo%2Fv1.1.1#15ef22fc1af72f2571331df18399185a9e4a4baa"
 dependencies = [
  "alloy-eips",
  "alloy-evm 0.27.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,12 +104,12 @@ kona-registry = { git = "https://github.com/ethereum-optimism/optimism", tag = "
 kona-genesis = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.14", default-features = false }
 
 # celo-kona
-celo-driver = { git = "https://github.com/celo-org/celo-kona", rev = "61caf47" }
-celo-proof = { git = "https://github.com/celo-org/celo-kona", rev = "61caf47" }
-celo-host = { git = "https://github.com/celo-org/celo-kona", rev = "61caf47" }
-celo-protocol = { git = "https://github.com/celo-org/celo-kona", rev = "61caf47", default-features = false }
-celo-genesis = { git = "https://github.com/celo-org/celo-kona", rev = "61caf47", default-features = false }
-celo-registry = { git = "https://github.com/celo-org/celo-kona", rev = "61caf47", default-features = false }
+celo-driver = { git = "https://github.com/celo-org/celo-kona", tag = "celo/v1.1.1" }
+celo-proof = { git = "https://github.com/celo-org/celo-kona", tag = "celo/v1.1.1" }
+celo-host = { git = "https://github.com/celo-org/celo-kona", tag = "celo/v1.1.1" }
+celo-protocol = { git = "https://github.com/celo-org/celo-kona", tag = "celo/v1.1.1", default-features = false }
+celo-genesis = { git = "https://github.com/celo-org/celo-kona", tag = "celo/v1.1.1", default-features = false }
+celo-registry = { git = "https://github.com/celo-org/celo-kona", tag = "celo/v1.1.1", default-features = false }
 
 # hana
 hana-blobstream = { git = "https://github.com/celestiaorg/hana", tag = "v1.6.0-mocha" }
@@ -203,10 +203,10 @@ op-alloy-rpc-types-engine = { git = "https://github.com/ethereum-optimism/optimi
 op-alloy-network = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.14", default-features = false }
 
 # Celo Alloy
-celo-alloy-consensus = { git = "https://github.com/celo-org/celo-kona", rev = "61caf47", default-features = false }
-celo-alloy-rpc-types = { git = "https://github.com/celo-org/celo-kona", rev = "61caf47", default-features = false }
-celo-alloy-rpc-types-engine = { git = "https://github.com/celo-org/celo-kona", rev = "61caf47", default-features = false }
-celo-alloy-network = { git = "https://github.com/celo-org/celo-kona", rev = "61caf47", default-features = false }
+celo-alloy-consensus = { git = "https://github.com/celo-org/celo-kona", tag = "celo/v1.1.1", default-features = false }
+celo-alloy-rpc-types = { git = "https://github.com/celo-org/celo-kona", tag = "celo/v1.1.1", default-features = false }
+celo-alloy-rpc-types-engine = { git = "https://github.com/celo-org/celo-kona", tag = "celo/v1.1.1", default-features = false }
+celo-alloy-network = { git = "https://github.com/celo-org/celo-kona", tag = "celo/v1.1.1", default-features = false }
 
 # Execution
 alloy-evm = { version = "0.27.2", default-features = false }
@@ -220,7 +220,7 @@ revm-precompile = { version = "32.1.0", default-features = false }
 op-revm = { version = "15.0.0", default-features = false }
 
 # Celo Execution
-alloy-celo-evm = { git = "https://github.com/celo-org/celo-kona", rev = "61caf47", default-features = false }
+alloy-celo-evm = { git = "https://github.com/celo-org/celo-kona", tag = "celo/v1.1.1", default-features = false }
 
 # SP1 v6.1.0 (Hypercube)
 sp1-sdk = { version = "=6.1.0", features = ["network", "blocking", "profiling"] }

--- a/utils/host/src/fetcher.rs
+++ b/utils/host/src/fetcher.rs
@@ -958,7 +958,7 @@ impl OPSuccinctDataFetcher {
             server: true,
             rollup_config_path: self.rollup_config_path.clone(),
             l1_config_path: self.l1_config_path.clone(),
-            enable_experimental_witness_endpoint: false,
+            enable_experimental_witness_endpoint: true,
         })
     }
 }


### PR DESCRIPTION
Bumps celo-kona to [`celo/v1.1.1`](https://github.com/celo-org/celo-kona/releases/tag/celo%2Fv1.1.1) and turns on the experimental witness endpoint, so op-succinct's witness generation fetches the execution witness via `debug_executePayload` against celo-reth nodes. The proving ELFs and vkeys are intentionally left unchanged.

Relates to https://github.com/celo-org/celo-blockchain-planning/issues/1376

## Why

On celo-reth, the per-node witness path (`L2StateNode` -> `debug_dbGet`) does not work: celo-reth's `debug_dbGet` only serves contract bytecode (a 33-byte `0x63`+code-hash key), not raw state-trie nodes, so witness generation fails with `error code -32602: Key must be 33 bytes, got 32` on any range that touches real state.

celo-kona `celo/v1.1.1` fixes the `debug_executePayload` witness endpoint (a payload-attributes type mismatch that made it a silent no-op against celo-reth). Enabling `enable_experimental_witness_endpoint` makes the host bulk-fetch the execution witness through `debug_executePayload` instead of walking state node by node, so proving succeeds.

## What changed

- Bump the celo-kona pin to `celo/v1.1.1` (`Cargo.toml`, `Cargo.lock`).
- `utils/host/src/fetcher.rs`: set `enable_experimental_witness_endpoint = true`.

## ELFs and vkeys are unchanged

The `celo/v1.1.1` fix is host-side (it changes how the host fetches the witness). `bin/client`, the fault-proof program, is unchanged from `celo/v1.1.0`, and v1.1.1's only other change is a patch bump of `anyhow` (1.0.102 -> 1.0.103, a soundness fix that does not affect program behavior). So the existing ELFs stay valid and the vkeys do not change: only the host binaries (proposer, challenger, game-monitor) need to be rebuilt and redeployed.

This PR deliberately does not update the committed ELFs. Bumping the celo-kona rev does rebuild them (the source revision changes), so the ELF-check CI reports a diff. That is expected here; the existing ELFs and on-chain vkeys stay in use.

## Prerequisites

- The L2 endpoint must serve `debug_executePayload` for the range being proven (proofs-history or archive node).
- If a proxyd fronts the L2 node, `debug_executePayload` must be whitelisted in its `rpc_method_mappings`.

## Validation

A `cost-estimator` run over a celo-sepolia range with real transactions (which previously failed with "Key must be 33 bytes") now completes: derivation reaches the L2 safe head, the blocks validate, and the proofs are generated.