### PR TITLE
game-monitor: classify execution-client-specific state-unavailable RPC errors

### DIFF
--- a/.github/workflows/cargo-tests.yml
+++ b/.github/workflows/cargo-tests.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Install Foundry
       uses: foundry-rs/foundry-toolchain@v1
       with:
-        version: nightly
+        version: nightly-d592b3e0f142d694c3be539702704a4a73238773
     - run: rustup toolchain install stable --profile minimal
     - name: Install protobuf compiler
       run: sudo apt-get update && sudo apt-get install -y protobuf-compiler

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: nightly-d592b3e0f142d694c3be539702704a4a73238773
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2

--- a/scripts/utils/bin/game_monitor.rs
+++ b/scripts/utils/bin/game_monitor.rs
@@ -1007,14 +1007,20 @@ enum FailureType {
     /// `-32011`). The proxy in front of the L1/L2 nodes returned 503 because none of its
     /// backends were healthy.
     NoHealthyBackend,
-    /// `No state available for block ...` (JSON-RPC code `-32002`). The RPC node pruned or
-    /// never had state for the requested historical block.
+    /// The RPC node pruned or never had state for the requested historical block. Each execution
+    /// client phrases this differently, so several anchors map here: Nethermind `No state
+    /// available for block ...` (JSON-RPC code `-32002`); geth path-scheme (PBSS) `state 0x... is
+    /// not available` / `historical state ... is not available`; and reth `state at block #N is
+    /// pruned` / `no state found for block ...` (forwarded through an Internal `-32603`).
     NoStateAvailable,
     /// `distance to target block exceeds maximum proof window` (JSON-RPC code `-32602`). The
     /// requested block is too far from the node's head for an `eth_getProof` call.
     ExceedsProofWindow,
-    /// `missing trie node ... is not available` (JSON-RPC code `-32000`). The RPC node is
-    /// missing a trie node for the requested state.
+    /// A trie node is missing from the RPC node's state DB. Two node implementations phrase this
+    /// differently: geth-style `missing trie node ... is not available` (JSON-RPC code `-32000`),
+    /// and Nethermind-style `MissingTrieNodeException: ... is missing from the DB` (surfaced as
+    /// JSON-RPC code `-32603` Internal error). Both mean the node pruned or never had the
+    /// requested state.
     MissingTrieNode,
     /// `Failed to fetch safe head` with a `dns error` cause. The op-node hostname could not be
     /// resolved (typically a transient cluster-DNS hiccup).
@@ -1071,6 +1077,16 @@ const FAILURE_PATTERNS: &[(&[&str], FailureType)] = &[
     (&["No state available for block"], FailureType::NoStateAvailable),
     (&["distance to target block exceeds maximum proof window"], FailureType::ExceedsProofWindow),
     (&["missing trie node"], FailureType::MissingTrieNode),
+    (&["MissingTrieNodeException"], FailureType::MissingTrieNode),
+    // geth path-scheme (PBSS) pruned/unavailable state: `state 0x… is not available` /
+    // `historical state … is not available`. Placed after the trie-node anchors so a geth or
+    // Nethermind `missing trie node … is not available` line classifies as MissingTrieNode.
+    (&["state", "is not available"], FailureType::NoStateAvailable),
+    // reth pruned/absent historical state: `state at block #N is pruned` /
+    // `no state found for block …`, forwarded through an Internal (-32603) error whose
+    // transparent inner message is the reth ProviderError text.
+    (&["is pruned"], FailureType::NoStateAvailable),
+    (&["no state found for block"], FailureType::NoStateAvailable),
     (&["Failed to fetch safe head", "dns error"], FailureType::DnsLookupFailure),
     (&["Temporary failure in name resolution"], FailureType::DnsLookupFailure),
     (


### PR DESCRIPTION
## What

game-monitor's cost-estimator failure classifier (`FAILURE_PATTERNS` in `game_monitor.rs`) anchored each "historical state unavailable" pattern on a single execution client's wording. The L1/L2 RPC endpoints are load-balanced across multiple client implementations, so the same failure phrased by a different client fell through to `FailureType::Unknown` and showed up as a false "failure type unknown", which the on-call alert keys on.

This is one example I observed which triggered the on-call alert since it was logged as "failure type unknown":
```log
thread 'main' (23676) panicked at scripts/utils/bin/cost_estimator.rs:126:20:
called `Result::unwrap()` on an `Err` value: JoinError::Panic(Id(1171), "called `Result::unwrap()` on an `Err` value: database error: failed to fetch code at 0xdadB0d80178819F2319190D340ce9A924f783711: server returned an error response: error code -32603: Internal error, data: \"Nethermind.Trie.MissingTrieNodeException...
```

Note that the ELF check CI is failing intentionally since https://github.com/celo-org/op-succinct/pull/148. We can update ELF files when we complete mainnet reth migration.

## Testing

`cargo check --bin game-monitor` passes.